### PR TITLE
Features/support for std #8

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,14 @@ Generate JUnit compatible XML reports in Rust.
     let mut ts2 = TestSuite::new("ts2");
     ts2.set_timestamp(timestamp);
 
-    let test_success = TestCase::success("good test", Duration::seconds(15), Some("MyClass".to_string()));
+    let test_success = TestCase::success("good test", Duration::seconds(15), Some("MyClass".to_string()), None);
     let test_error = TestCase::error(
         "error test",
         Duration::seconds(5),
         "git error",
         "unable to fetch",
+        None,
+        None,
         None,
     );
     let test_failure = TestCase::failure(
@@ -33,6 +35,8 @@ Generate JUnit compatible XML reports in Rust.
         Duration::seconds(10),
         "assert_eq",
         "not equal",
+        None,
+        None,
         None,
     );
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Generate JUnit compatible XML reports in Rust.
     let mut ts2 = TestSuite::new("ts2");
     ts2.set_timestamp(timestamp);
 
-    let test_success = TestCase::success("good test", Duration::seconds(15), Some("MyClass".to_string()), None);
+    let test_success = TestCase::success("good test", Duration::seconds(15), Some("MyClass".to_string()), None, None);
     let test_error = TestCase::error(
         "error test",
         Duration::seconds(5),

--- a/src/collections.rs
+++ b/src/collections.rs
@@ -67,6 +67,8 @@ pub struct TestCase {
     pub time: Duration,
     pub result: TestResult,
     pub classname: Option<String>,
+    pub sysout: Option<String>,
+    pub syserror: Option<String>,
 }
 
 /// Result of a test case
@@ -79,12 +81,20 @@ pub enum TestResult {
 
 impl TestCase {
     /// Creates a new successful `TestCase`
-    pub fn success(name: &str, time: Duration, classname: Option<String>) -> TestCase {
+    pub fn success(
+        name: &str,
+        time: Duration,
+        classname: Option<String>,
+        sysout: Option<String>,
+        syserror: Option<String>,
+    ) -> TestCase {
         TestCase {
             name: name.into(),
             time,
             result: TestResult::Success,
             classname,
+            sysout,
+            syserror,
         }
     }
 
@@ -105,6 +115,8 @@ impl TestCase {
         type_: &str,
         message: &str,
         classname: Option<String>,
+        sysout: Option<String>,
+        syserror: Option<String>,
     ) -> TestCase {
         TestCase {
             name: name.into(),
@@ -114,6 +126,8 @@ impl TestCase {
                 message: message.into(),
             },
             classname,
+            sysout,
+            syserror,
         }
     }
 
@@ -134,6 +148,8 @@ impl TestCase {
         type_: &str,
         message: &str,
         classname: Option<String>,
+        sysout: Option<String>,
+        syserror: Option<String>,
     ) -> TestCase {
         TestCase {
             name: name.into(),
@@ -143,6 +159,8 @@ impl TestCase {
                 message: message.into(),
             },
             classname,
+            sysout,
+            syserror,
         }
     }
 

--- a/src/collections.rs
+++ b/src/collections.rs
@@ -10,6 +10,8 @@ pub struct TestSuite {
     pub timestamp: DateTime<Utc>,
     pub hostname: String,
     pub testcases: Vec<TestCase>,
+    pub sysout: Option<String>,
+    pub syserror: Option<String>,
 }
 
 impl TestSuite {
@@ -21,6 +23,8 @@ impl TestSuite {
             name: name.into(),
             timestamp: Utc::now(),
             testcases: Vec::new(),
+            sysout: None,
+            syserror: None
         }
     }
 
@@ -39,6 +43,14 @@ impl TestSuite {
     /// By default the timestamp is set to the time when the `TestSuite` was created.
     pub fn set_timestamp(&mut self, timestamp: DateTime<Utc>) {
         self.timestamp = timestamp;
+    }
+
+    pub fn set_sysout(&mut self, sysout: String) {
+        self.sysout = Option::from(sysout);
+    }
+
+    pub fn set_syserror(&mut self, syserror: String) {
+        self.syserror = Option::from(syserror);
     }
 
     pub fn tests(&self) -> usize {

--- a/src/collections.rs
+++ b/src/collections.rs
@@ -24,7 +24,7 @@ impl TestSuite {
             timestamp: Utc::now(),
             testcases: Vec::new(),
             sysout: None,
-            syserror: None
+            syserror: None,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,12 +21,13 @@
 ///     let mut ts2 = TestSuite::new("ts2");
 ///     ts2.set_timestamp(timestamp);
 ///
-///     let test_success = TestCase::success("good test", Duration::seconds(15), None);
+///     let test_success = TestCase::success("good test", Duration::seconds(15), None, None,);
 ///     let test_error = TestCase::error(
 ///         "error test",
 ///         Duration::seconds(5),
 ///         "git error",
 ///         "unable to fetch",
+///         None,
 ///         None,
 ///     );
 ///     let test_failure = TestCase::failure(
@@ -35,6 +36,7 @@
 ///         "assert_eq",
 ///         "not equal",
 ///         Some("classname".to_string()),
+///         None,
 ///     );
 ///
 ///     ts2.add_testcase(test_success);
@@ -101,7 +103,11 @@ mod tests {
 
         assert_eq!(
             normalize(out),
-            "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<testsuites>\n  <testsuite id=\"0\" name=\"ts1\" package=\"testsuite/ts1\" tests=\"0\" errors=\"0\" failures=\"0\" hostname=\"localhost\" timestamp=\"1970-01-01T00:01:01+00:00\" time=\"0\">\n    <system-out />\n    <system-err />\n  </testsuite>\n  <testsuite id=\"1\" name=\"ts2\" package=\"testsuite/ts2\" tests=\"0\" errors=\"0\" failures=\"0\" hostname=\"localhost\" timestamp=\"1970-01-01T00:01:01+00:00\" time=\"0\">\n    <system-out />\n    <system-err />\n  </testsuite>\n</testsuites>"
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?>
+<testsuites>
+  <testsuite id=\"0\" name=\"ts1\" package=\"testsuite/ts1\" tests=\"0\" errors=\"0\" failures=\"0\" hostname=\"localhost\" timestamp=\"1970-01-01T00:01:01+00:00\" time=\"0\" />
+  <testsuite id=\"1\" name=\"ts2\" package=\"testsuite/ts2\" tests=\"0\" errors=\"0\" failures=\"0\" hostname=\"localhost\" timestamp=\"1970-01-01T00:01:01+00:00\" time=\"0\" />
+</testsuites>"
         );
     }
 
@@ -129,7 +135,11 @@ mod tests {
 
         assert_eq!(
             normalize(out),
-            "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<testsuites>\n  <testsuite id=\"0\" name=\"ts1\" package=\"testsuite/ts1\" tests=\"0\" errors=\"0\" failures=\"0\" hostname=\"localhost\" timestamp=\"1970-01-01T00:01:01+00:00\" time=\"0\">\n    <system-out />\n    <system-err />\n  </testsuite>\n  <testsuite id=\"1\" name=\"ts2\" package=\"testsuite/ts2\" tests=\"0\" errors=\"0\" failures=\"0\" hostname=\"localhost\" timestamp=\"1970-01-01T00:01:01+00:00\" time=\"0\">\n    <system-out />\n    <system-err />\n  </testsuite>\n</testsuites>"
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?>
+<testsuites>
+  <testsuite id=\"0\" name=\"ts1\" package=\"testsuite/ts1\" tests=\"0\" errors=\"0\" failures=\"0\" hostname=\"localhost\" timestamp=\"1970-01-01T00:01:01+00:00\" time=\"0\" />
+  <testsuite id=\"1\" name=\"ts2\" package=\"testsuite/ts2\" tests=\"0\" errors=\"0\" failures=\"0\" hostname=\"localhost\" timestamp=\"1970-01-01T00:01:01+00:00\" time=\"0\" />
+</testsuites>"
         );
     }
 
@@ -140,12 +150,14 @@ mod tests {
 
         let mut ts = TestSuite::new("ts");
 
-        let tc1 = TestCase::success("mysuccess", Duration::milliseconds(6001), None);
+        let tc1 = TestCase::success("mysuccess", Duration::milliseconds(6001), None, None, None);
         let tc2 = TestCase::error(
             "myerror",
             Duration::seconds(6),
             "Some Error",
             "An Error happened",
+            None,
+            None,
             None,
         );
         let tc3 = TestCase::failure(
@@ -153,6 +165,8 @@ mod tests {
             Duration::seconds(6),
             "Some failure",
             "A Failure happened",
+            None,
+            None,
             None,
         );
 
@@ -195,6 +209,8 @@ mod tests {
             "good test",
             Duration::milliseconds(15001),
             Some("MyClass".to_string()),
+            None,
+            None,
         );
         let test_error = TestCase::error(
             "error test",
@@ -202,12 +218,16 @@ mod tests {
             "git error",
             "unable to fetch",
             None,
+            None,
+            None,
         );
         let test_failure = TestCase::failure(
             "failure test",
             Duration::seconds(10),
             "assert_eq",
             "not equal",
+            None,
+            None,
             None,
         );
 
@@ -224,7 +244,19 @@ mod tests {
 
         assert_eq!(
             normalize(out),
-            "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<testsuites>\n  <testsuite id=\"0\" name=\"ts1\" package=\"testsuite/ts1\" tests=\"0\" errors=\"0\" failures=\"0\" hostname=\"localhost\" timestamp=\"1970-01-01T00:01:01+00:00\" time=\"0\">\n    <system-out />\n    <system-err />\n  </testsuite>\n  <testsuite id=\"1\" name=\"ts2\" package=\"testsuite/ts2\" tests=\"3\" errors=\"1\" failures=\"1\" hostname=\"localhost\" timestamp=\"1970-01-01T00:01:01+00:00\" time=\"30.001\">\n    <testcase name=\"good test\" classname=\"MyClass\" time=\"15.001\" />\n    <testcase name=\"error test\" time=\"5\">\n      <error type=\"git error\" message=\"unable to fetch\" />\n    </testcase>\n    <testcase name=\"failure test\" time=\"10\">\n      <failure type=\"assert_eq\" message=\"not equal\" />\n    </testcase>\n    <system-out />\n    <system-err />\n  </testsuite>\n</testsuites>"
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?>
+<testsuites>
+  <testsuite id=\"0\" name=\"ts1\" package=\"testsuite/ts1\" tests=\"0\" errors=\"0\" failures=\"0\" hostname=\"localhost\" timestamp=\"1970-01-01T00:01:01+00:00\" time=\"0\" />
+  <testsuite id=\"1\" name=\"ts2\" package=\"testsuite/ts2\" tests=\"3\" errors=\"1\" failures=\"1\" hostname=\"localhost\" timestamp=\"1970-01-01T00:01:01+00:00\" time=\"30.001\">
+    <testcase name=\"good test\" classname=\"MyClass\" time=\"15.001\" />
+    <testcase name=\"error test\" time=\"5\">
+      <error type=\"git error\" message=\"unable to fetch\" />
+    </testcase>
+    <testcase name=\"failure test\" time=\"10\">
+      <failure type=\"assert_eq\" message=\"not equal\" />
+    </testcase>
+  </testsuite>
+</testsuites>"
         );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 ///     let mut ts2 = TestSuite::new("ts2");
 ///     ts2.set_timestamp(timestamp);
 ///
-///     let test_success = TestCase::success("good test", Duration::seconds(15), None, None,);
+///     let test_success = TestCase::success("good test", Duration::seconds(15), None, None, None,);
 ///     let test_error = TestCase::error(
 ///         "error test",
 ///         Duration::seconds(5),
@@ -29,6 +29,7 @@
 ///         "unable to fetch",
 ///         None,
 ///         None,
+///         None
 ///     );
 ///     let test_failure = TestCase::failure(
 ///         "failure test",
@@ -36,6 +37,7 @@
 ///         "assert_eq",
 ///         "not equal",
 ///         Some("classname".to_string()),
+///         None,
 ///         None,
 ///     );
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,6 +114,66 @@ mod tests {
     }
 
     #[test]
+    fn add_empty_testsuite_single_with_sysout() {
+        use crate::Report;
+        use crate::TestSuite;
+        use crate::{TimeZone, Utc};
+
+        let timestamp = Utc.ymd(1970, 1, 1).and_hms(0, 1, 1);
+
+        let mut r = Report::new();
+        let mut ts1 = TestSuite::new("ts1");
+        ts1.set_sysout("Test sysout".to_string());
+        ts1.set_timestamp(timestamp);
+
+        r.add_testsuite(ts1);
+
+        let mut out: Vec<u8> = Vec::new();
+
+        r.write_xml(&mut out).unwrap();
+
+        assert_eq!(
+            normalize(out),
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?>
+<testsuites>
+  <testsuite id=\"0\" name=\"ts1\" package=\"testsuite/ts1\" tests=\"0\" errors=\"0\" failures=\"0\" hostname=\"localhost\" timestamp=\"1970-01-01T00:01:01+00:00\" time=\"0\">
+    <system-out>Test sysout</system-out>
+  </testsuite>
+</testsuites>"
+        );
+    }
+
+    #[test]
+    fn add_empty_testsuite_single_with_syserror() {
+        use crate::Report;
+        use crate::TestSuite;
+        use crate::{TimeZone, Utc};
+
+        let timestamp = Utc.ymd(1970, 1, 1).and_hms(0, 1, 1);
+
+        let mut r = Report::new();
+        let mut ts1 = TestSuite::new("ts1");
+        ts1.set_syserror("Test syserror".to_string());
+        ts1.set_timestamp(timestamp);
+
+        r.add_testsuite(ts1);
+
+        let mut out: Vec<u8> = Vec::new();
+
+        r.write_xml(&mut out).unwrap();
+
+        assert_eq!(
+            normalize(out),
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?>
+<testsuites>
+  <testsuite id=\"0\" name=\"ts1\" package=\"testsuite/ts1\" tests=\"0\" errors=\"0\" failures=\"0\" hostname=\"localhost\" timestamp=\"1970-01-01T00:01:01+00:00\" time=\"0\">
+    <system-err>Test syserror</system-err>
+  </testsuite>
+</testsuites>"
+        );
+    }
+
+    #[test]
     fn add_empty_testsuite_batch() {
         use crate::Report;
         use crate::TestSuite;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,7 +137,7 @@ mod tests {
             "<?xml version=\"1.0\" encoding=\"utf-8\"?>
 <testsuites>
   <testsuite id=\"0\" name=\"ts1\" package=\"testsuite/ts1\" tests=\"0\" errors=\"0\" failures=\"0\" hostname=\"localhost\" timestamp=\"1970-01-01T00:01:01+00:00\" time=\"0\">
-    <system-out>Test sysout</system-out>
+    <system-out><![CDATA[Test sysout]]></system-out>
   </testsuite>
 </testsuites>"
         );
@@ -167,7 +167,7 @@ mod tests {
             "<?xml version=\"1.0\" encoding=\"utf-8\"?>
 <testsuites>
   <testsuite id=\"0\" name=\"ts1\" package=\"testsuite/ts1\" tests=\"0\" errors=\"0\" failures=\"0\" hostname=\"localhost\" timestamp=\"1970-01-01T00:01:01+00:00\" time=\"0\">
-    <system-err>Test syserror</system-err>
+    <system-err><![CDATA[Test syserror]]></system-err>
   </testsuite>
 </testsuites>"
         );
@@ -378,15 +378,15 @@ mod tests {
   <testsuite id=\"0\" name=\"ts1\" package=\"testsuite/ts1\" tests=\"0\" errors=\"0\" failures=\"0\" hostname=\"localhost\" timestamp=\"1970-01-01T00:01:01+00:00\" time=\"0\" />
   <testsuite id=\"1\" name=\"ts2\" package=\"testsuite/ts2\" tests=\"3\" errors=\"1\" failures=\"1\" hostname=\"localhost\" timestamp=\"1970-01-01T00:01:01+00:00\" time=\"30.001\">
     <testcase name=\"good test\" classname=\"MyClass\" time=\"15.001\">
-      <system-out>Some sysout message</system-out>
+      <system-out><![CDATA[Some sysout message]]></system-out>
     </testcase>
     <testcase name=\"error test\" time=\"5\">
-      <system-err>Some syserror message</system-err>
+      <system-err><![CDATA[Some syserror message]]></system-err>
       <error type=\"git error\" message=\"unable to fetch\" />
     </testcase>
     <testcase name=\"failure test\" time=\"10\">
-      <system-out>Sysout and syserror mixed in</system-out>
-      <system-err>Another syserror message</system-err>
+      <system-out><![CDATA[Sysout and syserror mixed in]]></system-out>
+      <system-err><![CDATA[Another syserror message]]></system-err>
       <failure type=\"assert_eq\" message=\"not equal\" />
     </testcase>
   </testsuite>

--- a/src/reports.rs
+++ b/src/reports.rs
@@ -86,13 +86,17 @@ impl Report {
 
                 if let Some(sysout) = &tc.sysout {
                     ew.write(XmlEvent::start_element("system-out"))?;
+                    ew.write("<![CDATA[");
                     ew.write(sysout.as_str())?;
+                    ew.write("]]>");
                     ew.write(XmlEvent::end_element())?;
                 }
 
                 if let Some(syserror) = &tc.syserror {
                     ew.write(XmlEvent::start_element("system-err"))?;
+                    ew.write("<![CDATA[");
                     ew.write(syserror.as_str())?;
+                    ew.write("]]>");
                     ew.write(XmlEvent::end_element())?;
                 }
 
@@ -126,13 +130,17 @@ impl Report {
             }
             if let Some(sysout) = &ts.sysout {
                 ew.write(XmlEvent::start_element("system-out"))?;
+                ew.write("<![CDATA[");
                 ew.write(sysout.as_str())?;
+                ew.write("]]>");
                 ew.write(XmlEvent::end_element())?;
             }
 
             if let Some(syserror) = &ts.syserror {
                 ew.write(XmlEvent::start_element("system-err"))?;
+                ew.write("<![CDATA[");
                 ew.write(syserror.as_str())?;
+                ew.write("]]>");
                 ew.write(XmlEvent::end_element())?;
             }
 

--- a/src/reports.rs
+++ b/src/reports.rs
@@ -124,6 +124,17 @@ impl Report {
 
                 ew.write(XmlEvent::end_element())?;
             }
+            if let Some(sysout) = &ts.sysout {
+                ew.write(XmlEvent::start_element("system-out"))?;
+                ew.write(sysout.as_str())?;
+                ew.write(XmlEvent::end_element())?;
+            }
+
+            if let Some(syserror) = &ts.syserror {
+                ew.write(XmlEvent::start_element("system-err"))?;
+                ew.write(syserror.as_str())?;
+                ew.write(XmlEvent::end_element())?;
+            }
 
             ew.write(XmlEvent::end_element())?;
         }

--- a/src/reports.rs
+++ b/src/reports.rs
@@ -84,6 +84,18 @@ impl Report {
                     )?;
                 }
 
+                if let Some(sysout) = &tc.sysout {
+                    ew.write(XmlEvent::start_element("system-out"))?;
+                    ew.write(sysout.as_str())?;
+                    ew.write(XmlEvent::end_element())?;
+                }
+
+                if let Some(syserror) = &tc.syserror {
+                    ew.write(XmlEvent::start_element("system-err"))?;
+                    ew.write(syserror.as_str())?;
+                    ew.write(XmlEvent::end_element())?;
+                }
+
                 match tc.result {
                     TestResult::Success => {}
                     TestResult::Error {
@@ -112,14 +124,6 @@ impl Report {
 
                 ew.write(XmlEvent::end_element())?;
             }
-
-            //TODO: support system-out
-            ew.write(XmlEvent::start_element("system-out"))?;
-            ew.write(XmlEvent::end_element())?;
-
-            //TODO: support system-err
-            ew.write(XmlEvent::start_element("system-err"))?;
-            ew.write(XmlEvent::end_element())?;
 
             ew.write(XmlEvent::end_element())?;
         }

--- a/src/reports.rs
+++ b/src/reports.rs
@@ -86,17 +86,13 @@ impl Report {
 
                 if let Some(sysout) = &tc.sysout {
                     ew.write(XmlEvent::start_element("system-out"))?;
-                    ew.write("<![CDATA[");
-                    ew.write(sysout.as_str())?;
-                    ew.write("]]>");
+                    ew.write(XmlEvent::CData(sysout.as_str()))?;
                     ew.write(XmlEvent::end_element())?;
                 }
 
                 if let Some(syserror) = &tc.syserror {
                     ew.write(XmlEvent::start_element("system-err"))?;
-                    ew.write("<![CDATA[");
-                    ew.write(syserror.as_str())?;
-                    ew.write("]]>");
+                    ew.write(XmlEvent::CData(syserror.as_str()))?;
                     ew.write(XmlEvent::end_element())?;
                 }
 
@@ -130,17 +126,13 @@ impl Report {
             }
             if let Some(sysout) = &ts.sysout {
                 ew.write(XmlEvent::start_element("system-out"))?;
-                ew.write("<![CDATA[");
-                ew.write(sysout.as_str())?;
-                ew.write("]]>");
+                ew.write(XmlEvent::CData(sysout.as_str()))?;
                 ew.write(XmlEvent::end_element())?;
             }
 
             if let Some(syserror) = &ts.syserror {
                 ew.write(XmlEvent::start_element("system-err"))?;
-                ew.write("<![CDATA[");
-                ew.write(syserror.as_str())?;
-                ew.write("]]>");
+                ew.write(XmlEvent::CData(syserror.as_str()))?;
                 ew.write(XmlEvent::end_element())?;
             }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -19,13 +19,20 @@ fn reference_report() {
     let mut ts1 = TestSuite::new("ts1");
     ts1.set_timestamp(timestamp);
 
-    let test_success =
-        TestCase::success("test1", Duration::seconds(15), Some("MyClass".to_string()));
+    let test_success = TestCase::success(
+        "test1",
+        Duration::seconds(15),
+        Some("MyClass".to_string()),
+        None,
+        None,
+    );
     let test_error = TestCase::error(
         "test3",
         Duration::seconds(5),
         "git error",
         "Could not clone",
+        None,
+        None,
         None,
     );
     let test_failure = TestCase::failure(
@@ -33,6 +40,8 @@ fn reference_report() {
         Duration::seconds(10),
         "assert_eq",
         "What was not true",
+        None,
+        None,
         None,
     );
 
@@ -90,6 +99,8 @@ fn validate_generated_xml_schema() {
         "MyTest3",
         Duration::seconds(15),
         Some("MyClass".to_string()),
+        None,
+        None,
     );
     let test_error = TestCase::error(
         "Blabla",
@@ -97,9 +108,18 @@ fn validate_generated_xml_schema() {
         "git error",
         "Could not clone",
         None,
+        None,
+        None,
     );
-    let test_failure =
-        TestCase::failure("Burk", Duration::seconds(10), "asdfasf", "asdfajfhk", None);
+    let test_failure = TestCase::failure(
+        "Burk",
+        Duration::seconds(10),
+        "asdfasf",
+        "asdfajfhk",
+        None,
+        None,
+        None,
+    );
 
     ts1.add_testcase(test_success);
     ts1.add_testcase(test_failure);

--- a/tests/reference.xml
+++ b/tests/reference.xml
@@ -8,7 +8,5 @@
     <testcase name="test3" time="5">
       <error type="git error" message="Could not clone" />
     </testcase>
-    <system-out />
-    <system-err />
   </testsuite>
 </testsuites>


### PR DESCRIPTION
This brings up support for stdout and stderror according to the spec provided at https://llg.cubic.org/docs/junit/ 

Annoyingly JUNIT is not well documented but wildly implemented, but as it shows the sysout and syserror should exist inside of specific tescase and are optional, so when empty there is no reason to render them. I've implemented that accordingly, and added a test case suite to make sure that they both show up and not show up accordingly.

Important to note that this breaks the existing API due to needing extra 2 parameters for test cases. 