### PR TITLE
Switch to  builder pattern for setting optional fields.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## Added
+- `system_out` and `system_err` fields added
+
+## BREAKING CHANGES
+- Revamp the API to use the builder pattern. This makes the API more future proof and hopefully avoids breaking changes in the future when more optional fields are added.
+- Change error type to no longer expose the internals of the XML processsing.
+
 ## [0.3.0] - 2020-05-12
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 chrono = "0.4.11"
 xml-rs = "0.8.3"
 derive-getters = "0.1.0"
+thiserror = "1.0.19"
 
 [dev-dependencies]
 commandspec = "0.12.2"

--- a/README.md
+++ b/README.md
@@ -11,41 +11,32 @@ Generate JUnit compatible XML reports in Rust.
     use junit_report::{Report, TestCase, TestSuite, Duration, TimeZone, Utc};
     use std::str;
 
-
     let timestamp = Utc.ymd(1970, 1, 1).and_hms(0, 1, 1);
 
-    let mut r = Report::new();
-    let mut ts1 = TestSuite::new("ts1");
-    ts1.set_timestamp(timestamp);
-    let mut ts2 = TestSuite::new("ts2");
-    ts2.set_timestamp(timestamp);
-
-    let test_success = TestCase::success("good test", Duration::seconds(15), Some("MyClass".to_string()), None, None);
+    let test_success = TestCase::success("good test", Duration::seconds(15)).set_classname("MyClass");
     let test_error = TestCase::error(
         "error test",
         Duration::seconds(5),
         "git error",
         "unable to fetch",
-        None,
-        None,
-        None,
     );
     let test_failure = TestCase::failure(
         "failure test",
         Duration::seconds(10),
         "assert_eq",
         "not equal",
-        None,
-        None,
-        None,
     );
 
-    ts2.add_testcase(test_success);
-    ts2.add_testcase(test_error);
-    ts2.add_testcase(test_failure);
+    let ts1 = TestSuite::new("ts1").set_timestamp(timestamp);
 
-    r.add_testsuite(ts1);
-    r.add_testsuite(ts2);
+    let ts2 = TestSuite::new("ts2").set_timestamp(timestamp)
+        .add_testcase(test_success)
+        .add_testcase(test_error)
+        .add_testcase(test_failure);
+
+    let r = Report::new()
+        .add_testsuite(ts1)
+        .add_testsuite(ts2);
 
     let mut out: Vec<u8> = Vec::new();
 

--- a/src/collections.rs
+++ b/src/collections.rs
@@ -10,47 +10,52 @@ pub struct TestSuite {
     pub timestamp: DateTime<Utc>,
     pub hostname: String,
     pub testcases: Vec<TestCase>,
-    pub sysout: Option<String>,
-    pub syserror: Option<String>,
+    pub system_out: Option<String>,
+    pub system_err: Option<String>,
 }
 
 impl TestSuite {
     /// Create a new `TestSuite` with a given name
-    pub fn new(name: &str) -> TestSuite {
+    pub fn new(name: &str) -> Self {
         TestSuite {
             hostname: "localhost".into(),
             package: format!("testsuite/{}", &name),
             name: name.into(),
             timestamp: Utc::now(),
             testcases: Vec::new(),
-            sysout: None,
-            syserror: None,
+            system_out: None,
+            system_err: None,
         }
     }
 
     /// Add a [`TestCase`](../struct.TestCase.html) to the `TestSuite`.
-    pub fn add_testcase(&mut self, testcase: TestCase) {
+    pub fn add_testcase(mut self, testcase: TestCase) -> Self {
         self.testcases.push(testcase);
+        self
     }
 
     /// Add several [`TestCase`s](../struct.TestCase.html) from a Vec.
-    pub fn add_testcases(&mut self, testcases: impl IntoIterator<Item = TestCase>) {
+    pub fn add_testcases(mut self, testcases: impl IntoIterator<Item = TestCase>) -> Self {
         self.testcases.extend(testcases);
+        self
     }
 
     /// Set the timestamp of the given `TestSuite`.
     ///
     /// By default the timestamp is set to the time when the `TestSuite` was created.
-    pub fn set_timestamp(&mut self, timestamp: DateTime<Utc>) {
+    pub fn set_timestamp(mut self, timestamp: DateTime<Utc>) -> Self {
         self.timestamp = timestamp;
+        self
     }
 
-    pub fn set_sysout(&mut self, sysout: String) {
-        self.sysout = Option::from(sysout);
+    pub fn set_system_out(mut self, system_out: &str) -> Self {
+        self.system_out = Some(system_out.to_owned());
+        self
     }
 
-    pub fn set_syserror(&mut self, syserror: String) {
-        self.syserror = Option::from(syserror);
+    pub fn set_system_err(mut self, system_err: &str) -> Self {
+        self.system_err = Some(system_err.to_owned());
+        self
     }
 
     pub fn tests(&self) -> usize {
@@ -79,8 +84,8 @@ pub struct TestCase {
     pub time: Duration,
     pub result: TestResult,
     pub classname: Option<String>,
-    pub sysout: Option<String>,
-    pub syserror: Option<String>,
+    pub system_out: Option<String>,
+    pub system_err: Option<String>,
 }
 
 /// Result of a test case
@@ -93,21 +98,33 @@ pub enum TestResult {
 
 impl TestCase {
     /// Creates a new successful `TestCase`
-    pub fn success(
-        name: &str,
-        time: Duration,
-        classname: Option<String>,
-        sysout: Option<String>,
-        syserror: Option<String>,
-    ) -> TestCase {
+    pub fn success(name: &str, time: Duration) -> Self {
         TestCase {
             name: name.into(),
             time,
             result: TestResult::Success,
-            classname,
-            sysout,
-            syserror,
+            classname: None,
+            system_out: None,
+            system_err: None,
         }
+    }
+
+    /// Set the `classname` for the `TestCase`
+    pub fn set_classname(mut self, classname: &str) -> Self {
+        self.classname = Some(classname.to_owned());
+        self
+    }
+
+    /// Set the `system_out` for the `TestCase`
+    pub fn set_system_out(mut self, system_out: &str) -> Self {
+        self.system_out = Some(system_out.to_owned());
+        self
+    }
+
+    /// Set the `system_err` for the `TestCase`
+    pub fn set_system_err(mut self, system_err: &str) -> Self {
+        self.system_err = Some(system_err.to_owned());
+        self
     }
 
     /// Check if a `TestCase` is successful
@@ -121,15 +138,7 @@ impl TestCase {
     /// Creates a new erroneous `TestCase`
     ///
     /// An erroneous `TestCase` is one that encountered an unexpected error condition.
-    pub fn error(
-        name: &str,
-        time: Duration,
-        type_: &str,
-        message: &str,
-        classname: Option<String>,
-        sysout: Option<String>,
-        syserror: Option<String>,
-    ) -> TestCase {
+    pub fn error(name: &str, time: Duration, type_: &str, message: &str) -> Self {
         TestCase {
             name: name.into(),
             time,
@@ -137,9 +146,9 @@ impl TestCase {
                 type_: type_.into(),
                 message: message.into(),
             },
-            classname,
-            sysout,
-            syserror,
+            classname: None,
+            system_out: None,
+            system_err: None,
         }
     }
 
@@ -154,15 +163,7 @@ impl TestCase {
     /// Creates a new failed `TestCase`
     ///
     /// A failed `TestCase` is one where an explicit assertion failed
-    pub fn failure(
-        name: &str,
-        time: Duration,
-        type_: &str,
-        message: &str,
-        classname: Option<String>,
-        sysout: Option<String>,
-        syserror: Option<String>,
-    ) -> TestCase {
+    pub fn failure(name: &str, time: Duration, type_: &str, message: &str) -> Self {
         TestCase {
             name: name.into(),
             time,
@@ -170,9 +171,9 @@ impl TestCase {
                 type_: type_.into(),
                 message: message.into(),
             },
-            classname,
-            sysout,
-            syserror,
+            classname: None,
+            system_out: None,
+            system_err: None,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,38 +15,30 @@
 ///
 ///     let timestamp = Utc.ymd(1970, 1, 1).and_hms(0, 1, 1);
 ///
-///     let mut r = Report::new();
-///     let mut ts1 = TestSuite::new("ts1");
-///     ts1.set_timestamp(timestamp);
-///     let mut ts2 = TestSuite::new("ts2");
-///     ts2.set_timestamp(timestamp);
-///
-///     let test_success = TestCase::success("good test", Duration::seconds(15), None, None, None,);
+///     let test_success = TestCase::success("good test", Duration::seconds(15));
 ///     let test_error = TestCase::error(
 ///         "error test",
 ///         Duration::seconds(5),
 ///         "git error",
 ///         "unable to fetch",
-///         None,
-///         None,
-///         None
 ///     );
 ///     let test_failure = TestCase::failure(
 ///         "failure test",
 ///         Duration::seconds(10),
 ///         "assert_eq",
 ///         "not equal",
-///         Some("classname".to_string()),
-///         None,
-///         None,
-///     );
+///     ).set_classname("classname");
 ///
-///     ts2.add_testcase(test_success);
-///     ts2.add_testcase(test_error);
-///     ts2.add_testcase(test_failure);
+///     let ts1 = TestSuite::new("ts1").set_timestamp(timestamp);
 ///
-///     r.add_testsuite(ts1);
-///     r.add_testsuite(ts2);
+///     let ts2 = TestSuite::new("ts2").set_timestamp(timestamp)
+///       .add_testcase(test_success)
+///       .add_testcase(test_error)
+///       .add_testcase(test_failure);
+///
+///     let r = Report::new()
+///       .add_testsuite(ts1)
+///       .add_testsuite(ts2);
 ///
 ///     let mut out: Vec<u8> = Vec::new();
 ///
@@ -90,14 +82,10 @@ mod tests {
 
         let timestamp = Utc.ymd(1970, 1, 1).and_hms(0, 1, 1);
 
-        let mut r = Report::new();
-        let mut ts1 = TestSuite::new("ts1");
-        ts1.set_timestamp(timestamp);
-        let mut ts2 = TestSuite::new("ts2");
-        ts2.set_timestamp(timestamp);
+        let ts1 = TestSuite::new("ts1").set_timestamp(timestamp);
+        let ts2 = TestSuite::new("ts2").set_timestamp(timestamp);
 
-        r.add_testsuite(ts1);
-        r.add_testsuite(ts2);
+        let r = Report::new().add_testsuite(ts1).add_testsuite(ts2);
 
         let mut out: Vec<u8> = Vec::new();
 
@@ -121,12 +109,11 @@ mod tests {
 
         let timestamp = Utc.ymd(1970, 1, 1).and_hms(0, 1, 1);
 
-        let mut r = Report::new();
-        let mut ts1 = TestSuite::new("ts1");
-        ts1.set_sysout("Test sysout".to_string());
-        ts1.set_timestamp(timestamp);
+        let ts1 = TestSuite::new("ts1")
+            .set_system_out("Test sysout")
+            .set_timestamp(timestamp);
 
-        r.add_testsuite(ts1);
+        let r = Report::new().add_testsuite(ts1);
 
         let mut out: Vec<u8> = Vec::new();
 
@@ -151,12 +138,11 @@ mod tests {
 
         let timestamp = Utc.ymd(1970, 1, 1).and_hms(0, 1, 1);
 
-        let mut r = Report::new();
-        let mut ts1 = TestSuite::new("ts1");
-        ts1.set_syserror("Test syserror".to_string());
-        ts1.set_timestamp(timestamp);
+        let ts1 = TestSuite::new("ts1")
+            .set_system_err("Test syserror")
+            .set_timestamp(timestamp);
 
-        r.add_testsuite(ts1);
+        let r = Report::new().add_testsuite(ts1);
 
         let mut out: Vec<u8> = Vec::new();
 
@@ -181,15 +167,12 @@ mod tests {
 
         let timestamp = Utc.ymd(1970, 1, 1).and_hms(0, 1, 1);
 
-        let mut r = Report::new();
-        let mut ts1 = TestSuite::new("ts1");
-        ts1.set_timestamp(timestamp);
-        let mut ts2 = TestSuite::new("ts2");
-        ts2.set_timestamp(timestamp);
+        let ts1 = TestSuite::new("ts1").set_timestamp(timestamp);
+        let ts2 = TestSuite::new("ts2").set_timestamp(timestamp);
 
         let v = vec![ts1, ts2];
 
-        r.add_testsuites(v);
+        let r = Report::new().add_testsuites(v);
 
         let mut out: Vec<u8> = Vec::new();
 
@@ -210,45 +193,39 @@ mod tests {
         use crate::Duration;
         use crate::{TestCase, TestSuite};
 
-        let mut ts = TestSuite::new("ts");
+        let ts = TestSuite::new("ts");
 
-        let tc1 = TestCase::success("mysuccess", Duration::milliseconds(6001), None, None, None);
+        let tc1 = TestCase::success("mysuccess", Duration::milliseconds(6001));
         let tc2 = TestCase::error(
             "myerror",
             Duration::seconds(6),
             "Some Error",
             "An Error happened",
-            None,
-            None,
-            None,
         );
         let tc3 = TestCase::failure(
             "myerror",
             Duration::seconds(6),
             "Some failure",
             "A Failure happened",
-            None,
-            None,
-            None,
         );
 
         assert_eq!(0, ts.tests());
         assert_eq!(0, ts.errors());
         assert_eq!(0, ts.failures());
 
-        ts.add_testcase(tc1);
+        let ts = ts.add_testcase(tc1);
 
         assert_eq!(1, ts.tests());
         assert_eq!(0, ts.errors());
         assert_eq!(0, ts.failures());
 
-        ts.add_testcase(tc2);
+        let ts = ts.add_testcase(tc2);
 
         assert_eq!(2, ts.tests());
         assert_eq!(1, ts.errors());
         assert_eq!(0, ts.failures());
 
-        ts.add_testcase(tc3);
+        let ts = ts.add_testcase(tc3);
 
         assert_eq!(3, ts.tests());
         assert_eq!(1, ts.errors());
@@ -261,44 +238,29 @@ mod tests {
 
         let timestamp = Utc.ymd(1970, 1, 1).and_hms(0, 1, 1);
 
-        let mut r = Report::new();
-        let mut ts1 = TestSuite::new("ts1");
-        ts1.set_timestamp(timestamp);
-        let mut ts2 = TestSuite::new("ts2");
-        ts2.set_timestamp(timestamp);
-
-        let test_success = TestCase::success(
-            "good test",
-            Duration::milliseconds(15001),
-            Some("MyClass".to_string()),
-            None,
-            None,
-        );
+        let test_success =
+            TestCase::success("good test", Duration::milliseconds(15001)).set_classname("MyClass");
         let test_error = TestCase::error(
             "error test",
             Duration::seconds(5),
             "git error",
             "unable to fetch",
-            None,
-            None,
-            None,
         );
         let test_failure = TestCase::failure(
             "failure test",
             Duration::seconds(10),
             "assert_eq",
             "not equal",
-            None,
-            None,
-            None,
         );
 
-        ts2.add_testcase(test_success);
-        ts2.add_testcase(test_error);
-        ts2.add_testcase(test_failure);
+        let ts1 = TestSuite::new("ts1").set_timestamp(timestamp);
+        let ts2 = TestSuite::new("ts2")
+            .set_timestamp(timestamp)
+            .add_testcase(test_success)
+            .add_testcase(test_error)
+            .add_testcase(test_failure);
 
-        r.add_testsuite(ts1);
-        r.add_testsuite(ts2);
+        let r = Report::new().add_testsuite(ts1).add_testsuite(ts2);
 
         let mut out: Vec<u8> = Vec::new();
 
@@ -328,44 +290,33 @@ mod tests {
 
         let timestamp = Utc.ymd(1970, 1, 1).and_hms(0, 1, 1);
 
-        let mut r = Report::new();
-        let mut ts1 = TestSuite::new("ts1");
-        ts1.set_timestamp(timestamp);
-        let mut ts2 = TestSuite::new("ts2");
-        ts2.set_timestamp(timestamp);
-
-        let test_success = TestCase::success(
-            "good test",
-            Duration::milliseconds(15001),
-            Some("MyClass".to_string()),
-            Some("Some sysout message".to_string()),
-            None,
-        );
+        let test_success = TestCase::success("good test", Duration::milliseconds(15001))
+            .set_classname("MyClass")
+            .set_system_out("Some sysout message");
         let test_error = TestCase::error(
             "error test",
             Duration::seconds(5),
             "git error",
             "unable to fetch",
-            None,
-            None,
-            Some("Some syserror message".to_string()),
-        );
+        )
+        .set_system_err("Some syserror message");
         let test_failure = TestCase::failure(
             "failure test",
             Duration::seconds(10),
             "assert_eq",
             "not equal",
-            None,
-            Some("Sysout and syserror mixed in".to_string()),
-            Some("Another syserror message".to_string()),
-        );
+        )
+        .set_system_out("Sysout and syserror mixed in")
+        .set_system_err("Another syserror message");
 
-        ts2.add_testcase(test_success);
-        ts2.add_testcase(test_error);
-        ts2.add_testcase(test_failure);
+        let ts1 = TestSuite::new("ts1").set_timestamp(timestamp);
+        let ts2 = TestSuite::new("ts2")
+            .set_timestamp(timestamp)
+            .add_testcase(test_success)
+            .add_testcase(test_error)
+            .add_testcase(test_failure);
 
-        r.add_testsuite(ts1);
-        r.add_testsuite(ts2);
+        let r = Report::new().add_testsuite(ts1).add_testsuite(ts2);
 
         let mut out: Vec<u8> = Vec::new();
 

--- a/src/reports.rs
+++ b/src/reports.rs
@@ -33,13 +33,15 @@ impl Report {
     /// Add a [`TestSuite`](../struct.TestSuite.html) to this report.
     ///
     /// The function takes ownership of the supplied [`TestSuite`](../struct.TestSuite.html).
-    pub fn add_testsuite(&mut self, testsuite: TestSuite) {
+    pub fn add_testsuite(mut self, testsuite: TestSuite) -> Self {
         self.testsuites.push(testsuite);
+        self
     }
 
     /// Add multiple[`TestSuite`s](../struct.TestSuite.html) from an iterator.
-    pub fn add_testsuites(&mut self, testsuites: impl IntoIterator<Item = TestSuite>) {
+    pub fn add_testsuites(mut self, testsuites: impl IntoIterator<Item = TestSuite>) -> Self {
         self.testsuites.extend(testsuites);
+        self
     }
 
     //TODO: Use custom error to not expose xml-rs, maybe via failure
@@ -84,15 +86,15 @@ impl Report {
                     )?;
                 }
 
-                if let Some(sysout) = &tc.sysout {
+                if let Some(system_out) = &tc.system_out {
                     ew.write(XmlEvent::start_element("system-out"))?;
-                    ew.write(XmlEvent::CData(sysout.as_str()))?;
+                    ew.write(XmlEvent::CData(system_out.as_str()))?;
                     ew.write(XmlEvent::end_element())?;
                 }
 
-                if let Some(syserror) = &tc.syserror {
+                if let Some(system_err) = &tc.system_err {
                     ew.write(XmlEvent::start_element("system-err"))?;
-                    ew.write(XmlEvent::CData(syserror.as_str()))?;
+                    ew.write(XmlEvent::CData(system_err.as_str()))?;
                     ew.write(XmlEvent::end_element())?;
                 }
 
@@ -124,15 +126,15 @@ impl Report {
 
                 ew.write(XmlEvent::end_element())?;
             }
-            if let Some(sysout) = &ts.sysout {
+            if let Some(system_out) = &ts.system_out {
                 ew.write(XmlEvent::start_element("system-out"))?;
-                ew.write(XmlEvent::CData(sysout.as_str()))?;
+                ew.write(XmlEvent::CData(system_out.as_str()))?;
                 ew.write(XmlEvent::end_element())?;
             }
 
-            if let Some(syserror) = &ts.syserror {
+            if let Some(system_err) = &ts.system_err {
                 ew.write(XmlEvent::start_element("system-err"))?;
-                ew.write(XmlEvent::CData(syserror.as_str()))?;
+                ew.write(XmlEvent::CData(system_err.as_str()))?;
                 ew.write(XmlEvent::end_element())?;
             }
 

--- a/src/reports.rs
+++ b/src/reports.rs
@@ -2,9 +2,18 @@ use std::io::Write;
 
 use crate::collections::{TestResult, TestSuite};
 use derive_getters::Getters;
-use xml::writer::{self, EmitterConfig, XmlEvent};
+use xml::writer::{EmitterConfig, XmlEvent};
 
 pub use chrono::{DateTime, Duration, TimeZone, Utc};
+
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+/// Errors that can occur when creating a `Report`
+pub enum ReportError {
+    #[error("unable to write report")]
+    Write(#[from] xml::writer::Error),
+}
 
 fn decimal_seconds(d: &Duration) -> f64 {
     if let Some(n) = d.num_nanoseconds() {
@@ -44,9 +53,8 @@ impl Report {
         self
     }
 
-    //TODO: Use custom error to not expose xml-rs, maybe via failure
     /// Write the XML version of the Report to the given `Writer`.
-    pub fn write_xml<W: Write>(&self, sink: W) -> writer::Result<()> {
+    pub fn write_xml<W: Write>(&self, sink: W) -> Result<(), ReportError> {
         let mut ew = EmitterConfig::new()
             .perform_indent(true)
             .create_writer(sink);

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -15,41 +15,27 @@ fn reference_report() {
 
     let timestamp = Utc.ymd(2018, 4, 21).and_hms(12, 02, 0);
 
-    let mut r = Report::new();
-    let mut ts1 = TestSuite::new("ts1");
-    ts1.set_timestamp(timestamp);
-
-    let test_success = TestCase::success(
-        "test1",
-        Duration::seconds(15),
-        Some("MyClass".to_string()),
-        None,
-        None,
-    );
+    let test_success = TestCase::success("test1", Duration::seconds(15)).set_classname("MyClass");
     let test_error = TestCase::error(
         "test3",
         Duration::seconds(5),
         "git error",
         "Could not clone",
-        None,
-        None,
-        None,
     );
     let test_failure = TestCase::failure(
         "test2",
         Duration::seconds(10),
         "assert_eq",
         "What was not true",
-        None,
-        None,
-        None,
     );
 
-    ts1.add_testcase(test_success);
-    ts1.add_testcase(test_failure);
-    ts1.add_testcase(test_error);
+    let ts1 = TestSuite::new("ts1")
+        .set_timestamp(timestamp)
+        .add_testcase(test_success)
+        .add_testcase(test_failure)
+        .add_testcase(test_error);
 
-    r.add_testsuite(ts1);
+    let r = Report::new().add_testsuite(ts1);
 
     let mut out: Vec<u8> = Vec::new();
 
@@ -91,41 +77,22 @@ fn validate_generated_xml_schema() {
 
     let timestamp = Utc.ymd(2018, 4, 21).and_hms(12, 02, 0);
 
-    let mut r = Report::new();
-    let mut ts1 = TestSuite::new("Some Testsuite");
-    ts1.set_timestamp(timestamp);
-
-    let test_success = TestCase::success(
-        "MyTest3",
-        Duration::seconds(15),
-        Some("MyClass".to_string()),
-        None,
-        None,
-    );
+    let test_success = TestCase::success("MyTest3", Duration::seconds(15)).set_classname("MyClass");
     let test_error = TestCase::error(
         "Blabla",
         Duration::seconds(5),
         "git error",
         "Could not clone",
-        None,
-        None,
-        None,
     );
-    let test_failure = TestCase::failure(
-        "Burk",
-        Duration::seconds(10),
-        "asdfasf",
-        "asdfajfhk",
-        None,
-        None,
-        None,
-    );
+    let test_failure = TestCase::failure("Burk", Duration::seconds(10), "asdfasf", "asdfajfhk");
 
-    ts1.add_testcase(test_success);
-    ts1.add_testcase(test_failure);
-    ts1.add_testcase(test_error);
+    let ts1 = TestSuite::new("Some Testsuite")
+        .set_timestamp(timestamp)
+        .add_testcase(test_success)
+        .add_testcase(test_failure)
+        .add_testcase(test_error);
 
-    r.add_testsuite(ts1);
+    let r = Report::new().add_testsuite(ts1);
 
     let mut f = File::create("target/generated.xml").unwrap();
 


### PR DESCRIPTION
This avoids breaking changes in the future when adding new fields
and makes the API nicer to use.

@MalteSchledjewski @Puciek This is a breaking change but should make it more future proof by avoiding adding more optional fields. Would this work for you?