### PR TITLE
Support skipped testcase in generated junit report

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "junit-report"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Pascal Bach <pascal.bach@nextrem.ch>"]
 description = "Create JUnit compatible XML reports."
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "junit-report"
-version = "0.4.3"
+version = "0.5.0"
 authors = ["Pascal Bach <pascal.bach@nextrem.ch>"]
 description = "Create JUnit compatible XML reports."
 license = "MIT"

--- a/src/collections.rs
+++ b/src/collections.rs
@@ -70,6 +70,10 @@ impl TestSuite {
         self.testcases.iter().filter(|x| x.is_failure()).count()
     }
 
+    pub fn skipped(&self) -> usize {
+        self.testcases.iter().filter(|x| x.is_skipped()).count()
+    }
+
     pub fn time(&self) -> Duration {
         self.testcases
             .iter()
@@ -92,6 +96,7 @@ pub struct TestCase {
 #[derive(Debug, Clone)]
 pub enum TestResult {
     Success,
+    Skipped,
     Error { type_: String, message: String },
     Failure { type_: String, message: String },
 }
@@ -174,6 +179,25 @@ impl TestCase {
     /// Check if a `TestCase` failed
     pub fn is_failure(&self) -> bool {
         matches!(self.result, TestResult::Failure { .. })
+    }
+
+    /// Create a new ignored `TestCase`
+    ///
+    /// An ignored `TestCase` is one where an ignored or skipped
+    pub fn skipped(name: &str) -> Self {
+        TestCase {
+            name: name.into(),
+            time: Duration::zero(),
+            result: TestResult::Skipped,
+            classname: None,
+            system_out: None,
+            system_err: None,
+        }
+    }
+
+    /// Check if a `TestCase` ignored
+    pub fn is_skipped(&self) -> bool {
+        matches!(self.result, TestResult::Skipped)
     }
 }
 

--- a/src/reports.rs
+++ b/src/reports.rs
@@ -147,7 +147,7 @@ impl Report {
                             ew.write(XmlEvent::CData(&String::from_utf8_lossy(&data)))?;
                         }
                         ew.write(XmlEvent::end_element())?;
-                    },
+                    }
                     TestResult::Skipped => {
                         ew.write(XmlEvent::start_element("skipped"))?;
                         ew.write(XmlEvent::end_element())?;

--- a/src/reports.rs
+++ b/src/reports.rs
@@ -147,6 +147,10 @@ impl Report {
                             ew.write(XmlEvent::CData(&String::from_utf8_lossy(&data)))?;
                         }
                         ew.write(XmlEvent::end_element())?;
+                    },
+                    TestResult::Skipped => {
+                        ew.write(XmlEvent::start_element("skipped"))?;
+                        ew.write(XmlEvent::end_element())?;
                     }
                 };
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -28,12 +28,14 @@ fn reference_report() {
         "assert_eq",
         "What was not true",
     );
+    let test_ignored = TestCase::skipped("test4");
 
     let ts1 = TestSuite::new("ts1")
         .set_timestamp(timestamp)
         .add_testcase(test_success)
         .add_testcase(test_failure)
-        .add_testcase(test_error);
+        .add_testcase(test_error)
+        .add_testcase(test_ignored);
 
     let r = Report::new().add_testsuite(ts1);
 
@@ -85,12 +87,14 @@ fn validate_generated_xml_schema() {
         "Could not clone",
     );
     let test_failure = TestCase::failure("Burk", Duration::seconds(10), "asdfasf", "asdfajfhk");
+    let test_skipped = TestCase::skipped("Alpha");
 
     let ts1 = TestSuite::new("Some Testsuite")
         .set_timestamp(timestamp)
         .add_testcase(test_success)
         .add_testcase(test_failure)
-        .add_testcase(test_error);
+        .add_testcase(test_error)
+        .add_testcase(test_skipped);
 
     let r = Report::new().add_testsuite(ts1);
 

--- a/tests/reference.xml
+++ b/tests/reference.xml
@@ -1,12 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
-  <testsuite id="0" name="ts1" package="testsuite/ts1" tests="3" errors="1" failures="1" hostname="localhost" timestamp="2018-04-21T12:02:00+00:00" time="30">
+  <testsuite id="0" name="ts1" package="testsuite/ts1" tests="4" errors="1" failures="1" hostname="localhost" timestamp="2018-04-21T12:02:00+00:00" time="30">
     <testcase name="test1" classname="MyClass" time="15" />
     <testcase name="test2" time="10">
       <failure type="assert_eq" message="What was not true" />
     </testcase>
     <testcase name="test3" time="5">
       <error type="git error" message="Could not clone" />
+    </testcase>
+    <testcase name="test4" time="0">
+      <skipped />
     </testcase>
   </testsuite>
 </testsuites>


### PR DESCRIPTION
Changes:
- Added `Skipped` to `TestResult`
- Emit `skipped` to skipped testcase in XML
- Added `test_ignored` to cargo test cases
- Bump version