### PR TITLE
Switch from `chrono` to `time`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+# BREAKING CHANGES
+- Switch from `chrono` to `time`
+- Switch timestamp formatting (still compliant with both `RFC3339` and `ISO8601`)
 
 ## [0.6.0] - 2021-07-20
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,13 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-chrono = "0.4.11"
-xml-rs = "0.8.3"
 derive-getters = "0.2.0"
-thiserror = "1.0.19"
 strip-ansi-escapes = "0.1.0"
+thiserror = "1.0.19"
+time = { version = "0.3.4", features = ["formatting"] }
+xml-rs = "0.8.3"
 
 [dev-dependencies]
 commandspec = "0.12.2"
 doc-comment = "0.3.3"
+time = { version = "0.3.4", features = ["macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,9 @@ edition = "2018"
 derive-getters = "0.2.0"
 strip-ansi-escapes = "0.1.0"
 thiserror = "1.0.19"
-time = { version = "0.3.4", features = ["formatting"] }
+time = { version = "0.3.4", features = ["formatting", "macros"] }
 xml-rs = "0.8.3"
 
 [dev-dependencies]
 commandspec = "0.12.2"
 doc-comment = "0.3.3"
-time = { version = "0.3.4", features = ["macros"] }

--- a/README.md
+++ b/README.md
@@ -13,9 +13,8 @@ Generate JUnit compatible XML reports in Rust.
 
 ```rust
 
-    extern crate junit_report;
-
-    use junit_report::{ReportBuilder, TestCase, TestCaseBuilder, TestSuite, TestSuiteBuilder, Duration, TimeZone, Utc};
+    use junit_report::{ReportBuilder, TestCase, TestCaseBuilder, TestSuite, TestSuiteBuilder};
+    use time::{macros::datetime, Duration};
     use std::fs::File;
 
     // Create a successful test case
@@ -44,7 +43,7 @@ Generate JUnit compatible XML reports in Rust.
 
     // Then we create a second test suite called "ts2" and set an explicit time stamp
     // then we add all the test cases from above
-    let timestamp = Utc.ymd(1970, 1, 1).and_hms(0, 1, 1);
+    let timestamp = datetime!(1970-01-01 00:01:01 UTC);
     let ts2 = TestSuiteBuilder::new("ts2")
         .set_timestamp(timestamp)
         .add_testcase(test_success)

--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ Generate JUnit compatible XML reports in Rust.
 
 ```rust
 
-    use junit_report::{ReportBuilder, TestCase, TestCaseBuilder, TestSuite, TestSuiteBuilder};
-    use time::{macros::datetime, Duration};
+    use junit_report::{datetime, Duration, ReportBuilder, TestCase, TestCaseBuilder, TestSuite, TestSuiteBuilder};
     use std::fs::File;
 
     // Create a successful test case

--- a/src/collections.rs
+++ b/src/collections.rs
@@ -6,15 +6,14 @@
  */
 
 use derive_getters::Getters;
-
-pub use chrono::{DateTime, Duration, TimeZone, Utc};
+use time::{Duration, OffsetDateTime};
 
 /// A `TestSuite` groups together several [`TestCase`s](struct.TestCase.html).
 #[derive(Debug, Clone, Getters)]
 pub struct TestSuite {
     pub name: String,
     pub package: String,
-    pub timestamp: DateTime<Utc>,
+    pub timestamp: OffsetDateTime,
     pub hostname: String,
     pub testcases: Vec<TestCase>,
     pub system_out: Option<String>,
@@ -28,7 +27,7 @@ impl TestSuite {
             hostname: "localhost".into(),
             package: format!("testsuite/{}", &name),
             name: name.into(),
-            timestamp: Utc::now(),
+            timestamp: OffsetDateTime::now_utc(),
             testcases: Vec::new(),
             system_out: None,
             system_err: None,
@@ -48,7 +47,7 @@ impl TestSuite {
     /// Set the timestamp of the given `TestSuite`.
     ///
     /// By default the timestamp is set to the time when the `TestSuite` was created.
-    pub fn set_timestamp(&mut self, timestamp: DateTime<Utc>) {
+    pub fn set_timestamp(&mut self, timestamp: OffsetDateTime) {
         self.timestamp = timestamp;
     }
 
@@ -79,7 +78,7 @@ impl TestSuite {
     pub fn time(&self) -> Duration {
         self.testcases
             .iter()
-            .fold(Duration::zero(), |sum, d| sum + d.time)
+            .fold(Duration::ZERO, |sum, d| sum + d.time)
     }
 }
 
@@ -112,7 +111,7 @@ impl TestSuiteBuilder {
     /// Set the timestamp of the `TestSuiteBuilder`.
     ///
     /// By default the timestamp is set to the time when the `TestSuiteBuilder` was created.
-    pub fn set_timestamp(&mut self, timestamp: DateTime<Utc>) -> &mut Self {
+    pub fn set_timestamp(&mut self, timestamp: OffsetDateTime) -> &mut Self {
         self.testsuite.timestamp = timestamp;
         self
     }
@@ -236,7 +235,7 @@ impl TestCase {
     pub fn skipped(name: &str) -> Self {
         TestCase {
             name: name.into(),
-            time: Duration::zero(),
+            time: Duration::ZERO,
             result: TestResult::Skipped,
             classname: None,
             system_out: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,11 +10,10 @@
 /// ## Example
 ///
 /// ```rust
+///     use time::{Duration, macros::datetime};
+///     use junit_report::{ReportBuilder, TestCase, TestCaseBuilder, TestSuiteBuilder};
 ///
-///     use junit_report::{ReportBuilder, TestCase, TestCaseBuilder, TestSuiteBuilder, Duration, TimeZone, Utc};
-///
-///
-///     let timestamp = Utc.ymd(1970, 1, 1).and_hms(0, 1, 1);
+///     let timestamp = datetime!(1970-01-01 01:01 UTC);
 ///
 ///     let test_success = TestCase::success("good test", Duration::seconds(15));
 ///     let test_error = TestCase::error(
@@ -48,8 +47,6 @@
 ///
 ///     r.write_xml(&mut out).unwrap();
 /// ```
-pub use chrono::{DateTime, Duration, TimeZone, Utc};
-
 mod collections;
 mod reports;
 
@@ -58,14 +55,15 @@ pub use crate::reports::{Report, ReportBuilder, ReportError};
 
 #[cfg(test)]
 mod tests {
+    use crate::{Report, ReportBuilder, TestCase, TestCaseBuilder, TestSuite, TestSuiteBuilder};
+    use time::{macros::datetime, Duration};
+
     pub fn normalize(out: Vec<u8>) -> String {
         String::from_utf8(out).unwrap().replace("\r\n", "\n")
     }
 
     #[test]
     fn empty_testsuites() {
-        use crate::Report;
-
         let r = Report::new();
 
         let mut out: Vec<u8> = Vec::new();
@@ -80,11 +78,7 @@ mod tests {
 
     #[test]
     fn add_empty_testsuite_single() {
-        use crate::ReportBuilder;
-        use crate::TestSuiteBuilder;
-        use crate::{TimeZone, Utc};
-
-        let timestamp = Utc.ymd(1970, 1, 1).and_hms(0, 1, 1);
+        let timestamp = datetime!(1970-01-01 01:01 UTC);
 
         let ts1 = TestSuiteBuilder::new("ts1")
             .set_timestamp(timestamp)
@@ -106,19 +100,15 @@ mod tests {
             normalize(out),
             "<?xml version=\"1.0\" encoding=\"utf-8\"?>
 <testsuites>
-  <testsuite id=\"0\" name=\"ts1\" package=\"testsuite/ts1\" tests=\"0\" errors=\"0\" failures=\"0\" hostname=\"localhost\" timestamp=\"1970-01-01T00:01:01+00:00\" time=\"0\" />
-  <testsuite id=\"1\" name=\"ts2\" package=\"testsuite/ts2\" tests=\"0\" errors=\"0\" failures=\"0\" hostname=\"localhost\" timestamp=\"1970-01-01T00:01:01+00:00\" time=\"0\" />
+  <testsuite id=\"0\" name=\"ts1\" package=\"testsuite/ts1\" tests=\"0\" errors=\"0\" failures=\"0\" hostname=\"localhost\" timestamp=\"1970-01-01T01:01:00Z\" time=\"0\" />
+  <testsuite id=\"1\" name=\"ts2\" package=\"testsuite/ts2\" tests=\"0\" errors=\"0\" failures=\"0\" hostname=\"localhost\" timestamp=\"1970-01-01T01:01:00Z\" time=\"0\" />
 </testsuites>"
         );
     }
 
     #[test]
     fn add_empty_testsuite_single_with_sysout() {
-        use crate::ReportBuilder;
-        use crate::TestSuiteBuilder;
-        use crate::{TimeZone, Utc};
-
-        let timestamp = Utc.ymd(1970, 1, 1).and_hms(0, 1, 1);
+        let timestamp = datetime!(1970-01-01 01:01 UTC);
 
         let ts1 = TestSuiteBuilder::new("ts1")
             .set_system_out("Test sysout")
@@ -135,7 +125,7 @@ mod tests {
             normalize(out),
             "<?xml version=\"1.0\" encoding=\"utf-8\"?>
 <testsuites>
-  <testsuite id=\"0\" name=\"ts1\" package=\"testsuite/ts1\" tests=\"0\" errors=\"0\" failures=\"0\" hostname=\"localhost\" timestamp=\"1970-01-01T00:01:01+00:00\" time=\"0\">
+  <testsuite id=\"0\" name=\"ts1\" package=\"testsuite/ts1\" tests=\"0\" errors=\"0\" failures=\"0\" hostname=\"localhost\" timestamp=\"1970-01-01T01:01:00Z\" time=\"0\">
     <system-out><![CDATA[Test sysout]]></system-out>
   </testsuite>
 </testsuites>"
@@ -144,11 +134,7 @@ mod tests {
 
     #[test]
     fn add_empty_testsuite_single_with_syserror() {
-        use crate::ReportBuilder;
-        use crate::TestSuiteBuilder;
-        use crate::{TimeZone, Utc};
-
-        let timestamp = Utc.ymd(1970, 1, 1).and_hms(0, 1, 1);
+        let timestamp = datetime!(1970-01-01 01:01 UTC);
 
         let ts1 = TestSuiteBuilder::new("ts1")
             .set_system_err("Test syserror")
@@ -165,7 +151,7 @@ mod tests {
             normalize(out),
             "<?xml version=\"1.0\" encoding=\"utf-8\"?>
 <testsuites>
-  <testsuite id=\"0\" name=\"ts1\" package=\"testsuite/ts1\" tests=\"0\" errors=\"0\" failures=\"0\" hostname=\"localhost\" timestamp=\"1970-01-01T00:01:01+00:00\" time=\"0\">
+  <testsuite id=\"0\" name=\"ts1\" package=\"testsuite/ts1\" tests=\"0\" errors=\"0\" failures=\"0\" hostname=\"localhost\" timestamp=\"1970-01-01T01:01:00Z\" time=\"0\">
     <system-err><![CDATA[Test syserror]]></system-err>
   </testsuite>
 </testsuites>"
@@ -174,11 +160,7 @@ mod tests {
 
     #[test]
     fn add_empty_testsuite_batch() {
-        use crate::ReportBuilder;
-        use crate::TestSuiteBuilder;
-        use crate::{TimeZone, Utc};
-
-        let timestamp = Utc.ymd(1970, 1, 1).and_hms(0, 1, 1);
+        let timestamp = datetime!(1970-01-01 01:01 UTC);
 
         let ts1 = TestSuiteBuilder::new("ts1")
             .set_timestamp(timestamp)
@@ -199,17 +181,14 @@ mod tests {
             normalize(out),
             "<?xml version=\"1.0\" encoding=\"utf-8\"?>
 <testsuites>
-  <testsuite id=\"0\" name=\"ts1\" package=\"testsuite/ts1\" tests=\"0\" errors=\"0\" failures=\"0\" hostname=\"localhost\" timestamp=\"1970-01-01T00:01:01+00:00\" time=\"0\" />
-  <testsuite id=\"1\" name=\"ts2\" package=\"testsuite/ts2\" tests=\"0\" errors=\"0\" failures=\"0\" hostname=\"localhost\" timestamp=\"1970-01-01T00:01:01+00:00\" time=\"0\" />
+  <testsuite id=\"0\" name=\"ts1\" package=\"testsuite/ts1\" tests=\"0\" errors=\"0\" failures=\"0\" hostname=\"localhost\" timestamp=\"1970-01-01T01:01:00Z\" time=\"0\" />
+  <testsuite id=\"1\" name=\"ts2\" package=\"testsuite/ts2\" tests=\"0\" errors=\"0\" failures=\"0\" hostname=\"localhost\" timestamp=\"1970-01-01T01:01:00Z\" time=\"0\" />
 </testsuites>"
         );
     }
 
     #[test]
     fn count_tests() {
-        use crate::Duration;
-        use crate::{TestCase, TestSuite};
-
         let mut ts = TestSuite::new("ts");
 
         let tc1 = TestCase::success("mysuccess", Duration::milliseconds(6001));
@@ -251,9 +230,7 @@ mod tests {
 
     #[test]
     fn testcases_no_stdout_stderr() {
-        use crate::{Duration, ReportBuilder, TestCaseBuilder, TestSuiteBuilder, TimeZone, Utc};
-
-        let timestamp = Utc.ymd(1970, 1, 1).and_hms(0, 1, 1);
+        let timestamp = datetime!(1970-01-01 01:01 UTC);
 
         let test_success = TestCaseBuilder::success("good test", Duration::milliseconds(15001))
             .set_classname("MyClass")
@@ -296,8 +273,8 @@ mod tests {
             normalize(out),
             "<?xml version=\"1.0\" encoding=\"utf-8\"?>
 <testsuites>
-  <testsuite id=\"0\" name=\"ts1\" package=\"testsuite/ts1\" tests=\"0\" errors=\"0\" failures=\"0\" hostname=\"localhost\" timestamp=\"1970-01-01T00:01:01+00:00\" time=\"0\" />
-  <testsuite id=\"1\" name=\"ts2\" package=\"testsuite/ts2\" tests=\"3\" errors=\"1\" failures=\"1\" hostname=\"localhost\" timestamp=\"1970-01-01T00:01:01+00:00\" time=\"30.001\">
+  <testsuite id=\"0\" name=\"ts1\" package=\"testsuite/ts1\" tests=\"0\" errors=\"0\" failures=\"0\" hostname=\"localhost\" timestamp=\"1970-01-01T01:01:00Z\" time=\"0\" />
+  <testsuite id=\"1\" name=\"ts2\" package=\"testsuite/ts2\" tests=\"3\" errors=\"1\" failures=\"1\" hostname=\"localhost\" timestamp=\"1970-01-01T01:01:00Z\" time=\"30.001\">
     <testcase name=\"good test\" classname=\"MyClass\" time=\"15.001\" />
     <testcase name=\"error test\" time=\"5\">
       <error type=\"git error\" message=\"unable to fetch\" />
@@ -312,9 +289,7 @@ mod tests {
 
     #[test]
     fn test_cases_with_sysout_and_syserr() {
-        use crate::{Duration, ReportBuilder, TestCaseBuilder, TestSuiteBuilder, TimeZone, Utc};
-
-        let timestamp = Utc.ymd(1970, 1, 1).and_hms(0, 1, 1);
+        let timestamp = datetime!(1970-01-01 01:01 UTC);
 
         let test_success = TestCaseBuilder::success("good test", Duration::milliseconds(15001))
             .set_classname("MyClass")
@@ -361,8 +336,8 @@ mod tests {
             normalize(out),
             "<?xml version=\"1.0\" encoding=\"utf-8\"?>
 <testsuites>
-  <testsuite id=\"0\" name=\"ts1\" package=\"testsuite/ts1\" tests=\"0\" errors=\"0\" failures=\"0\" hostname=\"localhost\" timestamp=\"1970-01-01T00:01:01+00:00\" time=\"0\" />
-  <testsuite id=\"1\" name=\"ts2\" package=\"testsuite/ts2\" tests=\"3\" errors=\"1\" failures=\"1\" hostname=\"localhost\" timestamp=\"1970-01-01T00:01:01+00:00\" time=\"30.001\">
+  <testsuite id=\"0\" name=\"ts1\" package=\"testsuite/ts1\" tests=\"0\" errors=\"0\" failures=\"0\" hostname=\"localhost\" timestamp=\"1970-01-01T01:01:00Z\" time=\"0\" />
+  <testsuite id=\"1\" name=\"ts2\" package=\"testsuite/ts2\" tests=\"3\" errors=\"1\" failures=\"1\" hostname=\"localhost\" timestamp=\"1970-01-01T01:01:00Z\" time=\"30.001\">
     <testcase name=\"good test\" classname=\"MyClass\" time=\"15.001\">
       <system-out><![CDATA[Some sysout message]]></system-out>
     </testcase>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,7 @@
 /// ## Example
 ///
 /// ```rust
-///     use time::{Duration, macros::datetime};
-///     use junit_report::{ReportBuilder, TestCase, TestCaseBuilder, TestSuiteBuilder};
+///     use junit_report::{datetime, Duration, ReportBuilder, TestCase, TestCaseBuilder, TestSuiteBuilder};
 ///
 ///     let timestamp = datetime!(1970-01-01 01:01 UTC);
 ///
@@ -50,13 +49,17 @@
 mod collections;
 mod reports;
 
+pub use time::{macros::datetime, Duration, OffsetDateTime};
+
 pub use crate::collections::{TestCase, TestCaseBuilder, TestSuite, TestSuiteBuilder};
 pub use crate::reports::{Report, ReportBuilder, ReportError};
 
 #[cfg(test)]
 mod tests {
-    use crate::{Report, ReportBuilder, TestCase, TestCaseBuilder, TestSuite, TestSuiteBuilder};
-    use time::{macros::datetime, Duration};
+    use crate::{
+        datetime, Duration, Report, ReportBuilder, TestCase, TestCaseBuilder, TestSuite,
+        TestSuiteBuilder,
+    };
 
     pub fn normalize(out: Vec<u8>) -> String {
         String::from_utf8(out).unwrap().replace("\r\n", "\n")

--- a/tests/generated.xml
+++ b/tests/generated.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
-  <testsuite id="0" name="Some Testsuite" package="testsuite/Some Testsuite" tests="3" errors="1" failures="1" hostname="localhost" timestamp="2018-04-21T12:02:00+00:00" time="30">
+  <testsuite id="0" name="Some Testsuite" package="testsuite/Some Testsuite" tests="3" errors="1" failures="1" hostname="localhost" timestamp="2018-04-21T12:02:00Z" time="30">
     <testcase name="MyTest3" time="15" />
     <testcase name="Burk" time="10">
       <failure type="asdfasf" message="asdfajfhk" />

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -5,18 +5,15 @@
  * SPDX-License-Identifier:     MIT
  */
 
-extern crate chrono;
-extern crate junit_report;
+use commandspec::sh_command;
+use junit_report::{ReportBuilder, TestCase, TestCaseBuilder, TestSuiteBuilder};
+use std::fs::File;
+use std::io::Read;
+use time::{macros::datetime, Duration};
 
 #[test]
 fn reference_report() {
-    use junit_report::{
-        Duration, ReportBuilder, TestCase, TestCaseBuilder, TestSuiteBuilder, TimeZone, Utc,
-    };
-    use std::fs::File;
-    use std::io::Read;
-
-    let timestamp = Utc.ymd(2018, 4, 21).and_hms(12, 02, 0);
+    let timestamp = datetime!(2018-04-21 12:02 UTC);
 
     let test_success = TestCaseBuilder::success("test1", Duration::seconds(15))
         .set_classname("MyClass")
@@ -60,9 +57,6 @@ fn reference_report() {
     assert_eq!(report, reference);
 }
 
-#[macro_use]
-extern crate commandspec;
-
 #[test]
 fn validate_reference_xml_schema() {
     let res = sh_command!(
@@ -80,12 +74,7 @@ fn validate_reference_xml_schema() {
 
 #[test]
 fn validate_generated_xml_schema() {
-    use junit_report::{
-        Duration, ReportBuilder, TestCase, TestCaseBuilder, TestSuiteBuilder, TimeZone, Utc,
-    };
-    use std::fs::File;
-
-    let timestamp = Utc.ymd(2018, 4, 21).and_hms(12, 02, 0);
+    let timestamp = datetime!(2018-04-21 12:02 UTC);
 
     let test_success = TestCaseBuilder::success("MyTest3", Duration::seconds(15))
         .set_classname("MyClass")

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -6,10 +6,11 @@
  */
 
 use commandspec::sh_command;
-use junit_report::{ReportBuilder, TestCase, TestCaseBuilder, TestSuiteBuilder};
+use junit_report::{
+    datetime, Duration, ReportBuilder, TestCase, TestCaseBuilder, TestSuiteBuilder,
+};
 use std::fs::File;
 use std::io::Read;
-use time::{macros::datetime, Duration};
 
 #[test]
 fn reference_report() {

--- a/tests/reference.xml
+++ b/tests/reference.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
-  <testsuite id="0" name="ts1" package="testsuite/ts1" tests="4" errors="1" failures="1" hostname="localhost" timestamp="2018-04-21T12:02:00+00:00" time="30">
+  <testsuite id="0" name="ts1" package="testsuite/ts1" tests="4" errors="1" failures="1" hostname="localhost" timestamp="2018-04-21T12:02:00Z" time="30">
     <testcase name="test1" classname="MyClass" time="15" />
     <testcase name="test2" time="10">
       <failure type="assert_eq" message="What was not true" />


### PR DESCRIPTION
We would like to use this crate as a part of [cucumber](https://github.com/cucumber-rs/cucumber) testing framework. But `chrono` has [soundness issue](https://github.com/chronotope/chrono/issues/499) which has affected many crates in rust ecosystem:  [security audit check fails](https://github.com/cucumber-rs/cucumber/runs/4066141773?check_suite_focus=true), [reddit tread](https://www.reddit.com/r/rust/comments/qamgyh/comment/hh6rh6y/?utm_source=share&utm_medium=web2x&context=3).