### PR TITLE
Switch from `xml-rs` to `quick-xml` due to maintenance status.  

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,25 @@
+name: Security audit
+
+on:
+  push:
+    branches: ["main"]
+    tags: ["v*"]
+    paths: ["**/Cargo.toml"]
+  pull_request:
+    branches: ["main"]
+    paths: ["**/Cargo.toml"]
+  schedule:
+    - cron: "7 7 * * *"
+
+jobs:
+  cargo-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+      - uses: actions-rs/audit-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Bump Rust edition to 2021
+# BREAKING CHANGES
+- Switch from `xml-rs` to `quick-xml` due to maintenance status
+  - Change `Err` type of `Report::write_xml()`
+  - Remove indentations and newlines from the generated `Report`
+
 ## [0.7.1] - 2022-04-27
 
 - Added support for an optional `file` attribute in test cases

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,15 +7,16 @@ license = "MIT"
 repository = "https://github.com/bachp/junit-report-rs"
 keywords = ["junit", "xunit", "xml", "report"]
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 derive-getters = "0.2.0"
+quick-xml = "0.24.0"
 strip-ansi-escapes = "0.1.0"
-thiserror = "1.0.19"
 time = { version = "0.3.4", features = ["formatting", "macros"] }
-xml-rs = "0.8.3"
 
 [dev-dependencies]
 commandspec = "0.12.2"
 doc-comment = "0.3.3"
+once_cell = "1.14"
+regex = "1.6"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,54 +5,57 @@
  * SPDX-License-Identifier:     MIT
  */
 
-/// Create JUnit compatible XML reports.
-///
-/// ## Example
-///
-/// ```rust
-///     use junit_report::{datetime, Duration, ReportBuilder, TestCase, TestCaseBuilder, TestSuiteBuilder};
-///
-///     let timestamp = datetime!(1970-01-01 01:01 UTC);
-///
-///     let test_success = TestCase::success("good test", Duration::seconds(15));
-///     let test_error = TestCase::error(
-///         "error test",
-///         Duration::seconds(5),
-///         "git error",
-///         "unable to fetch",
-///     );
-///     let test_failure = TestCaseBuilder::failure(
-///         "failure test",
-///         Duration::seconds(10),
-///         "assert_eq",
-///         "not equal",
-///     ).set_classname("classname").set_filepath("./foo.rs")
-///     .build();
-///
-///     let ts1 = TestSuiteBuilder::new("ts1").set_timestamp(timestamp).build();
-///
-///     let ts2 = TestSuiteBuilder::new("ts2").set_timestamp(timestamp)
-///       .add_testcase(test_success)
-///       .add_testcase(test_error)
-///       .add_testcase(test_failure)
-///       .build();
-///
-///     let r = ReportBuilder::new()
-///       .add_testsuite(ts1)
-///       .add_testsuite(ts2)
-///       .build();
-///
-///     let mut out: Vec<u8> = Vec::new();
-///
-///     r.write_xml(&mut out).unwrap();
-/// ```
+//! Create JUnit compatible XML reports.
+//!
+//! ## Example
+//!
+//! ```rust
+//!     use junit_report::{datetime, Duration, ReportBuilder, TestCase, TestCaseBuilder, TestSuiteBuilder};
+//!
+//!     let timestamp = datetime!(1970-01-01 01:01 UTC);
+//!
+//!     let test_success = TestCase::success("good test", Duration::seconds(15));
+//!     let test_error = TestCase::error(
+//!         "error test",
+//!         Duration::seconds(5),
+//!         "git error",
+//!         "unable to fetch",
+//!     );
+//!     let test_failure = TestCaseBuilder::failure(
+//!         "failure test",
+//!         Duration::seconds(10),
+//!         "assert_eq",
+//!         "not equal",
+//!     ).set_classname("classname").set_filepath("./foo.rs")
+//!     .build();
+//!
+//!     let ts1 = TestSuiteBuilder::new("ts1").set_timestamp(timestamp).build();
+//!
+//!     let ts2 = TestSuiteBuilder::new("ts2").set_timestamp(timestamp)
+//!       .add_testcase(test_success)
+//!       .add_testcase(test_error)
+//!       .add_testcase(test_failure)
+//!       .build();
+//!
+//!     let r = ReportBuilder::new()
+//!       .add_testsuite(ts1)
+//!       .add_testsuite(ts2)
+//!       .build();
+//!
+//!     let mut out: Vec<u8> = Vec::new();
+//!
+//!     r.write_xml(&mut out).unwrap();
+//! ```
+
 mod collections;
 mod reports;
 
 pub use time::{macros::datetime, Duration, OffsetDateTime};
 
-pub use crate::collections::{TestCase, TestCaseBuilder, TestSuite, TestSuiteBuilder};
-pub use crate::reports::{Report, ReportBuilder, ReportError};
+pub use crate::{
+    collections::{TestCase, TestCaseBuilder, TestResult, TestSuite, TestSuiteBuilder},
+    reports::{Report, ReportBuilder},
+};
 
 #[cfg(test)]
 mod tests {
@@ -60,10 +63,6 @@ mod tests {
         datetime, Duration, Report, ReportBuilder, TestCase, TestCaseBuilder, TestSuite,
         TestSuiteBuilder,
     };
-
-    pub fn normalize(out: Vec<u8>) -> String {
-        String::from_utf8(out).unwrap().replace("\r\n", "\n")
-    }
 
     #[test]
     fn empty_testsuites() {
@@ -73,9 +72,10 @@ mod tests {
 
         r.write_xml(&mut out).unwrap();
 
+        // language=xml
         assert_eq!(
-            normalize(out),
-            "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<testsuites />"
+            String::from_utf8(out).unwrap(),
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites/>",
         );
     }
 
@@ -99,13 +99,15 @@ mod tests {
 
         r.write_xml(&mut out).unwrap();
 
+        // language=xml
         assert_eq!(
-            normalize(out),
-            "<?xml version=\"1.0\" encoding=\"utf-8\"?>
-<testsuites>
-  <testsuite id=\"0\" name=\"ts1\" package=\"testsuite/ts1\" tests=\"0\" errors=\"0\" failures=\"0\" hostname=\"localhost\" timestamp=\"1970-01-01T01:01:00Z\" time=\"0\" />
-  <testsuite id=\"1\" name=\"ts2\" package=\"testsuite/ts2\" tests=\"0\" errors=\"0\" failures=\"0\" hostname=\"localhost\" timestamp=\"1970-01-01T01:01:00Z\" time=\"0\" />
-</testsuites>"
+            String::from_utf8(out).unwrap(),
+            "\
+<?xml version=\"1.0\" encoding=\"utf-8\"?>\
+<testsuites>\
+  <testsuite id=\"0\" name=\"ts1\" package=\"testsuite/ts1\" tests=\"0\" errors=\"0\" failures=\"0\" hostname=\"localhost\" timestamp=\"1970-01-01T01:01:00Z\" time=\"0\"/>\
+  <testsuite id=\"1\" name=\"ts2\" package=\"testsuite/ts2\" tests=\"0\" errors=\"0\" failures=\"0\" hostname=\"localhost\" timestamp=\"1970-01-01T01:01:00Z\" time=\"0\"/>\
+</testsuites>",
         );
     }
 
@@ -124,14 +126,16 @@ mod tests {
 
         r.write_xml(&mut out).unwrap();
 
+        // language=xml
         assert_eq!(
-            normalize(out),
-            "<?xml version=\"1.0\" encoding=\"utf-8\"?>
-<testsuites>
-  <testsuite id=\"0\" name=\"ts1\" package=\"testsuite/ts1\" tests=\"0\" errors=\"0\" failures=\"0\" hostname=\"localhost\" timestamp=\"1970-01-01T01:01:00Z\" time=\"0\">
-    <system-out><![CDATA[Test sysout]]></system-out>
-  </testsuite>
-</testsuites>"
+            String::from_utf8(out).unwrap(),
+            "\
+<?xml version=\"1.0\" encoding=\"utf-8\"?>\
+<testsuites>\
+  <testsuite id=\"0\" name=\"ts1\" package=\"testsuite/ts1\" tests=\"0\" errors=\"0\" failures=\"0\" hostname=\"localhost\" timestamp=\"1970-01-01T01:01:00Z\" time=\"0\">\
+    <system-out><![CDATA[Test sysout]]></system-out>\
+  </testsuite>\
+</testsuites>",
         );
     }
 
@@ -150,14 +154,16 @@ mod tests {
 
         r.write_xml(&mut out).unwrap();
 
+        // language=xml
         assert_eq!(
-            normalize(out),
-            "<?xml version=\"1.0\" encoding=\"utf-8\"?>
-<testsuites>
-  <testsuite id=\"0\" name=\"ts1\" package=\"testsuite/ts1\" tests=\"0\" errors=\"0\" failures=\"0\" hostname=\"localhost\" timestamp=\"1970-01-01T01:01:00Z\" time=\"0\">
-    <system-err><![CDATA[Test syserror]]></system-err>
-  </testsuite>
-</testsuites>"
+            String::from_utf8(out).unwrap(),
+            "\
+<?xml version=\"1.0\" encoding=\"utf-8\"?>\
+<testsuites>\
+  <testsuite id=\"0\" name=\"ts1\" package=\"testsuite/ts1\" tests=\"0\" errors=\"0\" failures=\"0\" hostname=\"localhost\" timestamp=\"1970-01-01T01:01:00Z\" time=\"0\">\
+    <system-err><![CDATA[Test syserror]]></system-err>\
+  </testsuite>\
+</testsuites>",
         );
     }
 
@@ -180,13 +186,15 @@ mod tests {
 
         r.write_xml(&mut out).unwrap();
 
+        // language=xml
         assert_eq!(
-            normalize(out),
-            "<?xml version=\"1.0\" encoding=\"utf-8\"?>
-<testsuites>
-  <testsuite id=\"0\" name=\"ts1\" package=\"testsuite/ts1\" tests=\"0\" errors=\"0\" failures=\"0\" hostname=\"localhost\" timestamp=\"1970-01-01T01:01:00Z\" time=\"0\" />
-  <testsuite id=\"1\" name=\"ts2\" package=\"testsuite/ts2\" tests=\"0\" errors=\"0\" failures=\"0\" hostname=\"localhost\" timestamp=\"1970-01-01T01:01:00Z\" time=\"0\" />
-</testsuites>"
+            String::from_utf8(out).unwrap(),
+            "\
+<?xml version=\"1.0\" encoding=\"utf-8\"?>\
+<testsuites>\
+  <testsuite id=\"0\" name=\"ts1\" package=\"testsuite/ts1\" tests=\"0\" errors=\"0\" failures=\"0\" hostname=\"localhost\" timestamp=\"1970-01-01T01:01:00Z\" time=\"0\"/>\
+  <testsuite id=\"1\" name=\"ts2\" package=\"testsuite/ts2\" tests=\"0\" errors=\"0\" failures=\"0\" hostname=\"localhost\" timestamp=\"1970-01-01T01:01:00Z\" time=\"0\"/>\
+</testsuites>",
         );
     }
 
@@ -273,21 +281,23 @@ mod tests {
 
         r.write_xml(&mut out).unwrap();
 
+        // language=xml
         assert_eq!(
-            normalize(out),
-            "<?xml version=\"1.0\" encoding=\"utf-8\"?>
-<testsuites>
-  <testsuite id=\"0\" name=\"ts1\" package=\"testsuite/ts1\" tests=\"0\" errors=\"0\" failures=\"0\" hostname=\"localhost\" timestamp=\"1970-01-01T01:01:00Z\" time=\"0\" />
-  <testsuite id=\"1\" name=\"ts2\" package=\"testsuite/ts2\" tests=\"3\" errors=\"1\" failures=\"1\" hostname=\"localhost\" timestamp=\"1970-01-01T01:01:00Z\" time=\"30.001\">
-    <testcase name=\"good test\" time=\"15.001\" classname=\"MyClass\" file=\"./foo.rs\" />
-    <testcase name=\"error test\" time=\"5\">
-      <error type=\"git error\" message=\"unable to fetch\" />
-    </testcase>
-    <testcase name=\"failure test\" time=\"10\">
-      <failure type=\"assert_eq\" message=\"not equal\" />
-    </testcase>
-  </testsuite>
-</testsuites>"
+            String::from_utf8(out).unwrap(),
+            "\
+<?xml version=\"1.0\" encoding=\"utf-8\"?>\
+<testsuites>\
+  <testsuite id=\"0\" name=\"ts1\" package=\"testsuite/ts1\" tests=\"0\" errors=\"0\" failures=\"0\" hostname=\"localhost\" timestamp=\"1970-01-01T01:01:00Z\" time=\"0\"/>\
+  <testsuite id=\"1\" name=\"ts2\" package=\"testsuite/ts2\" tests=\"3\" errors=\"1\" failures=\"1\" hostname=\"localhost\" timestamp=\"1970-01-01T01:01:00Z\" time=\"30.001\">\
+    <testcase name=\"good test\" time=\"15.001\" classname=\"MyClass\" file=\"./foo.rs\"/>\
+    <testcase name=\"error test\" time=\"5\">\
+      <error type=\"git error\" message=\"unable to fetch\"/>\
+    </testcase>\
+    <testcase name=\"failure test\" time=\"10\">\
+      <failure type=\"assert_eq\" message=\"not equal\"/>\
+    </testcase>\
+  </testsuite>\
+</testsuites>",
         );
     }
 
@@ -337,23 +347,25 @@ mod tests {
 
         r.write_xml(&mut out).unwrap();
 
+        // language=xml
         assert_eq!(
-            normalize(out),
-            "<?xml version=\"1.0\" encoding=\"utf-8\"?>
-<testsuites>
-  <testsuite id=\"0\" name=\"ts1\" package=\"testsuite/ts1\" tests=\"0\" errors=\"0\" failures=\"0\" hostname=\"localhost\" timestamp=\"1970-01-01T01:01:00Z\" time=\"0\" />
-  <testsuite id=\"1\" name=\"ts2\" package=\"testsuite/ts2\" tests=\"3\" errors=\"1\" failures=\"1\" hostname=\"localhost\" timestamp=\"1970-01-01T01:01:00Z\" time=\"30.001\">
-    <testcase name=\"good test\" time=\"15.001\" classname=\"MyClass\" file=\"./foo.rs\">
-      <system-out><![CDATA[Some sysout message]]></system-out>
-    </testcase>
-    <testcase name=\"error test\" time=\"5\">
-      <error type=\"git error\" message=\"unable to fetch\"><![CDATA[Some syserror message]]></error>
-    </testcase>
-    <testcase name=\"failure test\" time=\"10\">
-      <failure type=\"assert_eq\" message=\"not equal\"><![CDATA[System out or error message]]><![CDATA[Another system error message]]></failure>
-    </testcase>
-  </testsuite>
-</testsuites>"
+            String::from_utf8(out).unwrap(),
+            "\
+<?xml version=\"1.0\" encoding=\"utf-8\"?>\
+<testsuites>\
+  <testsuite id=\"0\" name=\"ts1\" package=\"testsuite/ts1\" tests=\"0\" errors=\"0\" failures=\"0\" hostname=\"localhost\" timestamp=\"1970-01-01T01:01:00Z\" time=\"0\"/>\
+  <testsuite id=\"1\" name=\"ts2\" package=\"testsuite/ts2\" tests=\"3\" errors=\"1\" failures=\"1\" hostname=\"localhost\" timestamp=\"1970-01-01T01:01:00Z\" time=\"30.001\">\
+    <testcase name=\"good test\" time=\"15.001\" classname=\"MyClass\" file=\"./foo.rs\">\
+      <system-out><![CDATA[Some sysout message]]></system-out>\
+    </testcase>\
+    <testcase name=\"error test\" time=\"5\">\
+      <error type=\"git error\" message=\"unable to fetch\"><![CDATA[Some syserror message]]></error>\
+    </testcase>\
+    <testcase name=\"failure test\" time=\"10\">\
+      <failure type=\"assert_eq\" message=\"not equal\"><![CDATA[System out or error message]]><![CDATA[Another system error message]]></failure>\
+    </testcase>\
+  </testsuite>\
+</testsuites>",
         );
     }
 }

--- a/src/reports.rs
+++ b/src/reports.rs
@@ -228,13 +228,16 @@ impl ReportBuilder {
     }
 }
 
+/// [`Writer`] extension.
 trait WriterExt {
+    /// [`Write`]s in case `val` is [`Some`] or does nothing otherwise.
     fn write_opt<T>(
         &mut self,
         val: Option<T>,
         inner: impl FnOnce(&mut Self, T) -> Result<&mut Self>,
     ) -> Result<&mut Self>;
 
+    /// [`Write`]s every item of the [`Iterator`].
     fn write_iter<T, I>(
         &mut self,
         val: I,
@@ -269,7 +272,10 @@ impl<W: Write> WriterExt for Writer<W> {
     }
 }
 
+/// [`ElementWriter`] extension.
 trait ElementWriterExt<'a, W: Write> {
+    /// [`Writes`] with `inner` in case `is_empty` resolves to [`false`] or
+    /// [`Write`]s with [`ElementWriter::write_empty`] otherwise.
     fn write_empty_or_inner<Inner>(
         self,
         is_empty: impl FnOnce(&mut Self) -> bool,

--- a/tests/generated.xml
+++ b/tests/generated.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
   <testsuite id="0" name="Some Testsuite" package="testsuite/Some Testsuite" tests="3" errors="1" failures="1" hostname="localhost" timestamp="2018-04-21T12:02:00Z" time="30">
-    <testcase name="MyTest3" time="15" />
+    <testcase name="MyTest3" time="15"/>
     <testcase name="Burk" time="10">
-      <failure type="asdfasf" message="asdfajfhk" />
+      <failure type="asdfasf" message="asdfajfhk"/>
     </testcase>
     <testcase name="Blabla" time="5">
-      <error type="git error" message="Could not clone" />
+      <error type="git error" message="Could not clone"/>
     </testcase>
-    <system-out />
-    <system-err />
+    <system-out/>
+    <system-err/>
   </testsuite>
 </testsuites>

--- a/tests/reference.xml
+++ b/tests/reference.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
   <testsuite id="0" name="ts1" package="testsuite/ts1" tests="4" errors="1" failures="1" hostname="localhost" timestamp="2018-04-21T12:02:00Z" time="30">
-    <testcase name="test1" time="15" classname="MyClass" file="./foo.rs" />
+    <testcase name="test1" time="15" classname="MyClass" file="./foo.rs"/>
     <testcase name="test2" time="10">
-      <failure type="assert_eq" message="What was not true" />
+      <failure type="assert_eq" message="What was not true"/>
     </testcase>
     <testcase name="test3" time="5">
-      <error type="git error" message="Could not clone" />
+      <error type="git error" message="Could not clone"/>
     </testcase>
     <testcase name="test4" time="0">
-      <skipped />
+      <skipped/>
     </testcase>
   </testsuite>
 </testsuites>


### PR DESCRIPTION
Unfortunately `xml-rs` [looks unmaintained][1]. As we are using this crate in [`cucumber`][2] and would like to keep our dependencies up-to-date, this PR replaces `xml-rs` with `quick-xml` and adds `GitHub` Security Advisory CI job.  



[1]: https://github.com/netvl/xml-rs/issues/221
[2]: https://github.com/cucumber-rs/cucumber