### PR TITLE
Re-export quick-xml's `Error` type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Re-export `quick_xml::Error` as `junit_report::Error`
+
 ## [0.8.1] - 2022-09-10
 
 - Remove unsecure dev dependency from `failure`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@
 mod collections;
 mod reports;
 
+pub use quick_xml::Error;
 pub use time::{macros::datetime, Duration, OffsetDateTime};
 
 pub use crate::{


### PR DESCRIPTION
This change allows users to refer to the `Report::write_xml` return value without a direct dependency on `quick_xml`.

Closes https://github.com/bachp/junit-report-rs/issues/27