### PR TITLE
Upgrade to latest strip-ansi-escapes version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 [dependencies]
 derive-getters = "0.3.0"
 quick-xml = "0.30.0"
-strip-ansi-escapes = "0.1.0"
+strip-ansi-escapes = "0.2.0"
 time = { version = "0.3.4", features = ["formatting", "macros"] }
 
 [dev-dependencies]

--- a/src/reports.rs
+++ b/src/reports.rs
@@ -141,14 +141,14 @@ impl TestCase {
                                 |_| self.system_out.is_none() && self.system_err.is_none(),
                                 |w| {
                                     w.write_opt(self.system_out.as_ref(), |w, stdout| {
-                                        let data = strip_ansi_escapes::strip(stdout.as_str())?;
+                                        let data = strip_ansi_escapes::strip(stdout);
                                         w.write_event(Event::CData(BytesCData::new(
                                             String::from_utf8_lossy(&data),
                                         )))
                                         .map(|_| w)
                                     })?
                                     .write_opt(self.system_err.as_ref(), |w, stderr| {
-                                        let data = strip_ansi_escapes::strip(stderr.as_str())?;
+                                        let data = strip_ansi_escapes::strip(stderr);
                                         w.write_event(Event::CData(BytesCData::new(
                                             String::from_utf8_lossy(&data),
                                         )))
@@ -170,14 +170,14 @@ impl TestCase {
                                 |_| self.system_out.is_none() && self.system_err.is_none(),
                                 |w| {
                                     w.write_opt(self.system_out.as_ref(), |w, stdout| {
-                                        let data = strip_ansi_escapes::strip(stdout.as_str())?;
+                                        let data = strip_ansi_escapes::strip(stdout);
                                         w.write_event(Event::CData(BytesCData::new(
                                             String::from_utf8_lossy(&data),
                                         )))
                                         .map(|_| w)
                                     })?
                                     .write_opt(self.system_err.as_ref(), |w, stderr| {
-                                        let data = strip_ansi_escapes::strip(stderr.as_str())?;
+                                        let data = strip_ansi_escapes::strip(stderr);
                                         w.write_event(Event::CData(BytesCData::new(
                                             String::from_utf8_lossy(&data),
                                         )))


### PR DESCRIPTION
Hey @bachp! This dependency bump would be helpful for us at @MaterializeInc. It's a lightly modified version of https://github.com/bachp/junit-report-rs/pull/35 with a small modification to fix compilation with the new API.