### PR TITLE
Feat/fix testcase stdout and add trace property

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -50,6 +56,7 @@ dependencies = [
  "derive-getters",
  "doc-comment",
  "once_cell",
+ "pretty_assertions",
  "quick-xml",
  "regex",
  "strip-ansi-escapes",
@@ -73,6 +80,16 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
+dependencies = [
+ "diff",
+ "yansi",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -241,3 +258,9 @@ dependencies = [
  "proc-macro2",
  "quote",
 ]
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,5 @@ time = { version = "0.3.4", features = ["formatting", "macros"] }
 [dev-dependencies]
 doc-comment = "0.3.3"
 once_cell = "1.14"
+pretty_assertions = "1.4.0"
 regex = "1.6"

--- a/src/collections.rs
+++ b/src/collections.rs
@@ -149,8 +149,16 @@ pub struct TestCase {
 pub enum TestResult {
     Success,
     Skipped,
-    Error { type_: String, message: String },
-    Failure { type_: String, message: String },
+    Error {
+        type_: String,
+        message: String,
+        cause: Option<String>,
+    },
+    Failure {
+        type_: String,
+        message: String,
+        cause: Option<String>,
+    },
 }
 
 impl TestCase {
@@ -202,6 +210,7 @@ impl TestCase {
             result: TestResult::Error {
                 type_: type_.into(),
                 message: message.into(),
+                cause: None,
             },
             classname: None,
             filepath: None,
@@ -225,6 +234,7 @@ impl TestCase {
             result: TestResult::Failure {
                 type_: type_.into(),
                 message: message.into(),
+                cause: None,
             },
             classname: None,
             filepath: None,
@@ -294,6 +304,18 @@ impl TestCaseBuilder {
     /// Set the `system_err` for the `TestCase`
     pub fn set_system_err(&mut self, system_err: &str) -> &mut Self {
         self.testcase.system_err = Some(system_err.to_owned());
+        self
+    }
+
+    /// Set the `result.trace` for the `TestCase`
+    ///
+    /// It has no effect on successful `TestCase`s.
+    pub fn set_trace(&mut self, trace: &str) -> &mut Self {
+        match self.testcase.result {
+            TestResult::Error { ref mut cause, .. } => *cause = Some(trace.to_owned()),
+            TestResult::Failure { ref mut cause, .. } => *cause = Some(trace.to_owned()),
+            _ => {}
+        }
         self
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,7 @@ mod tests {
         datetime, Duration, Report, ReportBuilder, TestCase, TestCaseBuilder, TestSuite,
         TestSuiteBuilder,
     };
+    use pretty_assertions::assert_eq;
 
     #[test]
     fn empty_testsuites() {
@@ -360,10 +361,13 @@ mod tests {
       <system-out><![CDATA[Some sysout message]]></system-out>\
     </testcase>\
     <testcase name=\"error test\" time=\"5\">\
-      <error type=\"git error\" message=\"unable to fetch\"><![CDATA[Some syserror message]]></error>\
+      <error type=\"git error\" message=\"unable to fetch\"/>\
+      <system-err><![CDATA[Some syserror message]]></system-err>\
     </testcase>\
     <testcase name=\"failure test\" time=\"10\">\
-      <failure type=\"assert_eq\" message=\"not equal\"><![CDATA[System out or error message]]><![CDATA[Another system error message]]></failure>\
+      <failure type=\"assert_eq\" message=\"not equal\"/>\
+      <system-out><![CDATA[System out or error message]]></system-out>\
+      <system-err><![CDATA[Another system error message]]></system-err>\
     </testcase>\
   </testsuite>\
 </testsuites>",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -373,4 +373,69 @@ mod tests {
 </testsuites>",
         );
     }
+
+    #[test]
+    fn test_cases_with_trace() {
+        let timestamp = datetime!(1970-01-01 01:01 UTC);
+
+        let test_success = TestCaseBuilder::success("good test", Duration::milliseconds(15001))
+            .set_classname("MyClass")
+            .set_filepath("./foo.rs")
+            .set_trace("Some trace message") // This should be ignored
+            .build();
+        let test_error = TestCaseBuilder::error(
+            "error test",
+            Duration::seconds(5),
+            "git error",
+            "unable to fetch",
+        )
+        .set_trace("Some error trace")
+        .build();
+        let test_failure = TestCaseBuilder::failure(
+            "failure test",
+            Duration::seconds(10),
+            "assert_eq",
+            "not equal",
+        )
+        .set_trace("Some failure trace")
+        .build();
+
+        let ts1 = TestSuiteBuilder::new("ts1")
+            .set_timestamp(timestamp)
+            .build();
+        let ts2 = TestSuiteBuilder::new("ts2")
+            .set_timestamp(timestamp)
+            .add_testcase(test_success)
+            .add_testcase(test_error)
+            .add_testcase(test_failure)
+            .build();
+
+        let r = ReportBuilder::new()
+            .add_testsuite(ts1)
+            .add_testsuite(ts2)
+            .build();
+
+        let mut out: Vec<u8> = Vec::new();
+
+        r.write_xml(&mut out).unwrap();
+
+        // language=xml
+        assert_eq!(
+            String::from_utf8(out).unwrap(),
+            "\
+<?xml version=\"1.0\" encoding=\"utf-8\"?>\
+<testsuites>\
+  <testsuite id=\"0\" name=\"ts1\" package=\"testsuite/ts1\" tests=\"0\" errors=\"0\" failures=\"0\" hostname=\"localhost\" timestamp=\"1970-01-01T01:01:00Z\" time=\"0\"/>\
+  <testsuite id=\"1\" name=\"ts2\" package=\"testsuite/ts2\" tests=\"3\" errors=\"1\" failures=\"1\" hostname=\"localhost\" timestamp=\"1970-01-01T01:01:00Z\" time=\"30.001\">\
+    <testcase name=\"good test\" time=\"15.001\" classname=\"MyClass\" file=\"./foo.rs\"/>\
+    <testcase name=\"error test\" time=\"5\">\
+      <error type=\"git error\" message=\"unable to fetch\"><![CDATA[Some error trace]]></error>\
+    </testcase>\
+    <testcase name=\"failure test\" time=\"10\">\
+      <failure type=\"assert_eq\" message=\"not equal\"><![CDATA[Some failure trace]]></failure>\
+    </testcase>\
+  </testsuite>\
+</testsuites>",
+        );
+    }
 }

--- a/src/reports.rs
+++ b/src/reports.rs
@@ -123,23 +123,49 @@ impl TestCase {
                         TestResult::Error {
                             ref type_,
                             ref message,
+                            ref cause,
                         } => w
                             .create_element("error")
                             .with_attributes([
                                 ("type", type_.as_str()),
                                 ("message", message.as_str()),
                             ])
-                            .write_empty(),
+                            .write_empty_or_inner(
+                                |_| cause.is_none(),
+                                |w| {
+                                    w.write_opt(cause.as_ref(), |w, cause| {
+                                        let data = BytesCData::new(cause.as_str());
+                                        w.write_event(Event::CData(BytesCData::new(
+                                            String::from_utf8_lossy(&data),
+                                        )))
+                                        .map(|_| w)
+                                    })
+                                    .map(drop)
+                                },
+                            ),
                         TestResult::Failure {
                             ref type_,
                             ref message,
+                            ref cause,
                         } => w
                             .create_element("failure")
                             .with_attributes([
                                 ("type", type_.as_str()),
                                 ("message", message.as_str()),
                             ])
-                            .write_empty(),
+                            .write_empty_or_inner(
+                                |_| cause.is_none(),
+                                |w| {
+                                    w.write_opt(cause.as_ref(), |w, cause| {
+                                        let data = BytesCData::new(cause.as_str());
+                                        w.write_event(Event::CData(BytesCData::new(
+                                            String::from_utf8_lossy(&data),
+                                        )))
+                                        .map(|_| w)
+                                    })
+                                    .map(drop)
+                                },
+                            ),
                         TestResult::Skipped => w.create_element("skipped").write_empty(),
                     }?
                     .write_opt(self.system_out.as_ref(), |w, out| {


### PR DESCRIPTION
I think #12 was actually a misread of the schema and has been merged too fast. In my understanding `system-out` and `system-err` are separated from the error or failure cause.

From the [schema] mentioned in #12:
> Contains as a text node relevant data for the error, e.g., a stack trace

stack trace `!=` stdout + stderr (even if they can be sometime related, by being a subset for example).

This PR revert the `system-out` and `system-err`, and add an additional property to error and failure types. I did not want to break the API so I introduced `set_trace` on `TestCaseBuilder` which ignore non erroneous results.