### PR TITLE
Added message and type to TestResult::Skipped

### DIFF
--- a/src/collections.rs
+++ b/src/collections.rs
@@ -149,6 +149,11 @@ pub struct TestCase {
 pub enum TestResult {
     Success,
     Skipped,
+    SkippedWithCause {
+        type_: String,
+        message: String,
+        cause: Option<String>,
+    },
     Error {
         type_: String,
         message: String,
@@ -263,9 +268,31 @@ impl TestCase {
         }
     }
 
+    /// Create a new ignored `TestCase` with an ignore cause
+    ///
+    /// An ignored `TestCase` is one where an ignored or skipped
+    pub fn skipped_with_cause(name: &str, type_: &str, message: &str) -> Self {
+        TestCase {
+            name: name.into(),
+            time: Duration::ZERO,
+            result: TestResult::SkippedWithCause {
+                type_: type_.into(),
+                message: message.into(),
+                cause: None,
+            },
+            classname: None,
+            filepath: None,
+            system_out: None,
+            system_err: None,
+        }
+    }
+
     /// Check if a `TestCase` ignored
     pub fn is_skipped(&self) -> bool {
-        matches!(self.result, TestResult::Skipped)
+        matches!(
+            self.result,
+            TestResult::Skipped | TestResult::SkippedWithCause { .. }
+        )
     }
 }
 
@@ -343,6 +370,15 @@ impl TestCaseBuilder {
     pub fn skipped(name: &str) -> Self {
         TestCaseBuilder {
             testcase: TestCase::skipped(name),
+        }
+    }
+
+    /// Creates a new TestCaseBuilder for an ignored `TestCase`, with a cause
+    ///
+    /// An ignored `TestCase` is one where an ignored or skipped
+    pub fn skipped_with_cause(name: &str, type_: &str, message: &str) -> Self {
+        TestCaseBuilder {
+            testcase: TestCase::skipped_with_cause(name, type_, message),
         }
     }
 

--- a/src/reports.rs
+++ b/src/reports.rs
@@ -176,6 +176,30 @@ impl TestCase {
                             .create_element("skipped")
                             .write_empty()
                             .map_err(Error::from),
+                        TestResult::SkippedWithCause {
+                            ref type_,
+                            ref message,
+                            ref cause,
+                        } => w
+                            .create_element("skipped")
+                            .with_attributes([
+                                ("type", type_.as_str()),
+                                ("message", message.as_str()),
+                            ])
+                            .write_empty_or_inner(
+                                |_| cause.is_none(),
+                                |w| {
+                                    w.write_opt(cause.as_ref(), |w, cause| {
+                                        let data = BytesCData::new(cause.as_str());
+                                        w.write_event(Event::CData(BytesCData::new(
+                                            String::from_utf8_lossy(&data),
+                                        )))
+                                        .map_err(Error::from)
+                                        .map(|_| w)
+                                    })
+                                    .map(drop)
+                                },
+                            ),
                     }?
                     .write_opt(
                         self.system_out.as_ref(),


### PR DESCRIPTION
Improves traceability of skipped test cases.